### PR TITLE
Add an (unsatisfied) gatk2 package requirement.

### DIFF
--- a/gatk2/gatk2_macros.xml
+++ b/gatk2/gatk2_macros.xml
@@ -1,6 +1,7 @@
 <macros>
   <xml name="requirements">
     <requirements>
+      <requirement type="package">gatk2</requirement>
       <requirement type="package" version="0.1.19">samtools</requirement>
       <requirement type="set_environment">GATK2_PATH</requirement>
       <requirement type="set_environment">GATK2_SITE_OPTIONS</requirement>


### PR DESCRIPTION
This is useful for system administrators which need to load modules
(e.g. JDK 1.7) by adding appropriate commands to
<tool_dependencies_dir>/gatk2/default/env.sh .

I didn't push this directly because I'd like this to be reviewed and approved.
