### PR TITLE
Reorganised EMBOSS Datatypes

### DIFF
--- a/datatypes/emboss_datatypes/datatypes_conf.xml
+++ b/datatypes/emboss_datatypes/datatypes_conf.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0"?>
 <datatypes>
     <registration>
-        <datatype extension="acedb" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <!-- Programme specific or otherwise unknown -->
         <datatype extension="btwisted" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="cai" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="charge" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="checktrans" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="chips" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="clustal" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="codata" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="codcmp" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="coderet" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="compseq" type="galaxy.datatypes.data:Text" subclass="True"/>
@@ -17,82 +15,88 @@
         <datatype extension="cusp" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="cut" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="dan" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="dbmotif" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="diffseq" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="digest" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="dreg" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="einverted" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="embl" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="epestfind" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="equicktandem" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="est2genome" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="etandem" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="excel" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="feattable" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="fitch" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="freak" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="fuzznuc" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="fuzzpro" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="fuzztran" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="garnier" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="gcg" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="geecee" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="genbank" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="helixturnhelix" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="hennig86" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="hmoment" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="ig" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="isochore" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="match" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="nametable" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="needle" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="newcpgreport" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="newcpgseek" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="noreturn" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="palindrome" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="pepcoil" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="pepinfo" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="pepstats" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="polydot" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="preg" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="prettyseq" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="primersearch" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="showfeat" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="showorf" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="sixpack" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="strider" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="supermatcher" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="syco" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="textsearch" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="vectorstrip" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="wobble" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="wordcount" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <!-- Report formats http://emboss.sourceforge.net/docs/themes/ReportFormats.html -->
+        <datatype extension="dbmotif" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="diffseq" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="excel" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="feattable" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="motif" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="regions" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="seqtable" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="simple" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="table" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="tagseq" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <!-- Sequence formats http://emboss.sourceforge.net/docs/themes/SequenceFormats.html -->
+        <datatype extension="acedb" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="clustal" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="codata" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="embl" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="fitch" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="gcg" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="genbank" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="hennig86" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="ig" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="jackknifer" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="jackknifernon" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="mega" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="meganon" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="ncbi" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="nexus" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="nexusnon" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="phylip" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="phylipnon" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="pir" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="staden" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <datatype extension="swiss" type="galaxy.datatypes.data:Text" subclass="True"/>
+        <!-- Alignment Formats http://emboss.sourceforge.net/docs/themes/AlignFormats.html -->
         <datatype extension="markx0" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="markx1" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="markx10" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="markx2" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="markx3" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="match" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="mega" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="meganon" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="motif" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="nametable" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="ncbi" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="needle" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="newcpgreport" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="newcpgseek" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="nexus" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="nexusnon" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="noreturn" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="pair" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="palindrome" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="pepcoil" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="pepinfo" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="pepstats" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="phylip" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="phylipnon" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="pir" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="polydot" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="preg" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="prettyseq" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="primersearch" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="regions" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="score" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="seqtable" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="showfeat" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="showorf" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="simple" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="sixpack" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="srs" type="galaxy.datatypes.data:Text" subclass="True"/>
         <datatype extension="srspair" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="staden" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="strider" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="supermatcher" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="swiss" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="syco" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="table" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="tagseq" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="textsearch" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="vectorstrip" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="wobble" type="galaxy.datatypes.data:Text" subclass="True"/>
-        <datatype extension="wordcount" type="galaxy.datatypes.data:Text" subclass="True"/>
     </registration>
 </datatypes>


### PR DESCRIPTION
Based on information from
- http://emboss.sourceforge.net/docs/themes/AlignFormats.html
- http://emboss.sourceforge.net/docs/themes/FeatureFormats.html
- http://emboss.sourceforge.net/docs/themes/SequenceFormats.html
- http://emboss.sourceforge.net/docs/themes/ReportFormats.html

The emboss datatypes were reorganised into separate categories. However, some datatypes overlap
significantly. For example, the EMBOSS `swiss` format is a sequence, report, and feature format.
This overlap could cause issues (depending on your point of view), as an EMBOSS tool producing a
"report" type output, would also depend on the sequence format datatypes.
