### PR TITLE
Fix uniq.xml typo by removing redundant help value

### DIFF
--- a/file_manipulation/uniq.xml
+++ b/file_manipulation/uniq.xml
@@ -15,8 +15,8 @@
   </command>
   <inputs>
     <param name="input" type="data" format="tabular,text" label="from query" />
-    <param name="ignore_case" type="boolean" label="ignore differences in case when comparing" truevalue="-f" falsevalue="false" checked="false" help="ignore differences in case when comparing"/>
-    <param name="is_numeric" type="boolean" label="column only contains numeric values" truevalue="-n" falsevalue="false" checked="false" help="did the calumn have numeric values"/>
+    <param name="ignore_case" type="boolean" label="Ignore differences in case when comparing" truevalue="-f" falsevalue="false" checked="false" />
+    <param name="is_numeric" type="boolean" label="Column only contains numeric values" truevalue="-n" falsevalue="false" checked="false" />
     <conditional name="adv_opts">
         <param name="adv_opts_selector" type="select" label="Advanced Options">
           <option value="basic" selected="True">Hide Advanced Options</option>


### PR DESCRIPTION
On a related point, the README file says "the uniq.xml and the sort_rows tools are moved to the unix tools" but I'm not sure where that is?