### PR TITLE
aragorn_out_to_gff3.py: Handle no space seq. ID

### DIFF
--- a/tools/rna_tools/trna_prediction/aragorn_out_to_gff3.py
+++ b/tools/rna_tools/trna_prediction/aragorn_out_to_gff3.py
@@ -18,7 +18,8 @@ print '##gff-version 3'
 for line in sys.stdin:
     if line.startswith('>'):
         genome_id = line[1:].strip()
-        genome_id = genome_id[0:genome_id.index(' ')]
+        if ' ' in genome_id:
+            genome_id = genome_id[0:genome_id.index(' ')]
     else:
         data = line.split()
         if len(data) == 5:


### PR DESCRIPTION
Fix the error message:
```
Traceback (most recent call last):
  File "bin/aragorn_out_to_gff3.py", line 21, in <module>
    genome_id = genome_id[0:genome_id.index(' ')]
ValueError: substring not found
```