### PR TITLE
Update OpenSwathWorkflow.xml

### DIFF
--- a/tools/openms/OpenSwathWorkflow.xml
+++ b/tools/openms/OpenSwathWorkflow.xml
@@ -7,12 +7,22 @@
   </macros>
   <expand macro="stdio"/>
   <expand macro="requirements"/>
-  <command>OpenSwathWorkflow
-
--in
-  #for token in $param_in:
-    $token
-  #end for
+  <command>
+#import re
+#set $input_files = []
+#for infile in $param_in:
+  #if str($infile.ext) == 'mzxml':
+    #set $file_extension = '.mzXML'
+  #else:
+    #set $file_extension = '.mzML'
+  #end if
+  #set $input_name = '"' + re.sub('\W','_',$infile.display_name) + $file_extension + '"'
+  #silent $input_files.append($input_name)
+  ln -s -f '${infile}' ${input_name};
+#end for
+#set $infiles = ' '.join($input_files)
+OpenSwathWorkflow
+-in $infiles
 #if $param_tr:
   -tr $param_tr
 #end if


### PR DESCRIPTION
Create symbolic links to input datasets.  OpenSwath uses the filename extension to determine whether the input is in mzML or mzXML format.