### PR TITLE
Add a "stop-gap" fix for the Yosemite OS to the recipe for installing

### DIFF
--- a/packages/package_fiji_20141125/tool_dependencies.xml
+++ b/packages/package_fiji_20141125/tool_dependencies.xml
@@ -13,9 +13,22 @@
                 <actions os="darwin" architecture="x86_64">
                     <action type="download_by_url">http://fiji.sc/downloads/Life-Line/fiji-macosx-20141125.dmg</action>
                     <action type="shell_command">
-                    	hdiutil attach fiji-macosx-20141125.dmg &amp;&amp;
-                    	cp -R /Volumes/Fiji/Fiji.app/ $INSTALL_DIR &amp;&amp;
-                    	hdiutil detach /Volumes/Fiji
+                        hdiutil attach fiji-macosx-20141125.dmg &amp;&amp;
+                        cp -R /Volumes/Fiji/Fiji.app/ $INSTALL_DIR &amp;&amp;
+                        hdiutil detach /Volumes/Fiji
+                        ## The ImageJ launcher contained in this version of Fiji will not
+                        ## run on Yosemite due to some operating system change.  The following
+                        ## block will download the fixed ImageJ launcher for Yosemite.  This is
+                        ## kind of a stop-gap measure for this recipe only (notice the use of
+                        ## wget, which is not an approved best practice).  This problem affects
+                        ## only those running Yosemite, and will be eliminated in the next
+                        ## stable version of Fiji when it is released.
+                        if [[ `sw_vers -productVersion | tr -d '.'` -ge 1010 ]]; then
+                            wget http://jenkins.imagej.net/job/ImageJ-launcher/label=MacOSX/lastSuccessfulBuild/artifact/target/nar/imagej-launcher-3.3.1-SNAPSHOT-x86_64-MacOSX-gcc-executable/bin/x86_64-MacOSX-gcc/imagej-launcher &amp;&amp;
+                            xattr -c imagej-launcher &amp;&amp;
+                            chmod +x imagej-launcher &amp;&amp;
+                            mv imagej-launcher $INSTALL_DIR/Contents/MacOS/ImageJ-macosx
+                        fi
                     </action>
                 </actions>
                 <actions>


### PR DESCRIPTION
version 20141125 of the Fiji package.