### PR TITLE
General cleanup of ImageJ2 tools:

### DIFF
--- a/tools/image_processing/imagej2/imagej2_adjust_threshold_binary/imagej2_adjust_threshold_binary.xml
+++ b/tools/image_processing/imagej2/imagej2_adjust_threshold_binary/imagej2_adjust_threshold_binary.xml
@@ -1,36 +1,64 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<tool id="imagej2_adjust_threshold_binary" name="Adjust binary threshold" version="1.0.0">
-    <description>with ImageJ2</description>
+<tool id="imagej2_adjust_threshold_binary" name="Adjust threshold" version="@WRAPPER_VERSION@.0">
+    <description>of binary image with ImageJ2</description>
     <macros>
         <import>imagej2_macros.xml</import>
     </macros>
-    <expand macro="fiji_20141125_requirements" />
+    <expand macro="fiji_requirements" />
     <command>
 <![CDATA[
     python $__tool_directory__/imagej2_adjust_threshold_binary.py
     --input "$input"
     --input_datatype $input.ext
-    @adjust_threshold_binary_args@
+    --threshold_min $threshold_min
+    --threshold_max $threshold_max
+    --method $method
+    --display $display
+    --dark_background $dark_background
+    --stack_histogram $stack_histogram
     --jython_script $__tool_directory__/jython_script.py
-    --output_datatype $output_datatype
+    --output_datatype $output.ext
     --output "$output"
 ]]>
     </command>
     <inputs>
         <param format="bmp,eps,gif,jpg,pcx,pgm,png,psd,tiff" name="input" type="data" label="Select image"/>
-        <expand macro="adjust_threshold_binary_params" />
-        <param name="output_datatype" type="select" label="Save as format">
-            <expand macro="image_datatypes" />
+        <param name="threshold_min" type="float" value="0" min="0" max="255" label="Minimum threshold value" />
+        <param name="threshold_max" type="float" value="0" min="0" max="255" label="Maximum threshold value" />
+        <param name="method" type="select" label="Method" help="The Default method is the modified IsoData algorithm.">
+            <option value="Default" selected="True">Default</option>
+            <option value="Huang">Huang</option>
+            <option value="Intermodes">Intermodes</option>
+            <option value="IsoData">IsoData</option>
+            <option value="IJ_IsoData">IJ_IsoData</option>
+            <option value="Li">Li</option>
+            <option value="MaxEntropy">MaxEntropy</option>
+            <option value="Mean">Mean</option>
+            <option value="MinError">MinError</option>
+            <option value="Minimum">Minimum</option>
+            <option value="Moments">Moments</option>
+            <option value="Otsu">Otsu</option>
+            <option value="RenyiEntropy">RenyiEntropy</option>
+            <option value="Shanbhag">Shanbhag</option>
+            <option value="Triangle">Triangle</option>
+            <option value="Yen">Yen</option>
+        </param>
+        <param name="display" type="select" label="Display">
+            <option value="red" selected="True">Red</option>
+            <option value="bw">Black and White</option>
+            <option value="over_under">Over/Under</option>
+        </param>
+        <param name="dark_background" type="select" label="Dark background" help="Select yes if features are lighter than the background.">
+            <option value="no" selected="True">No</option>
+            <option value="yes">Yes</option>
+        </param>
+        <param name="stack_histogram" type="select" label="Stack histogram" help="Select yes to first compute the histogram of the whole stack (or hyperstack) and then compute the threshold based on that histogram.">
+            <option value="no" selected="True">No</option>
+            <option value="yes">Yes</option>
         </param>
     </inputs>
     <outputs>
-        <data name="output" format_source="input" label="${tool.name} on ${on_string}">
-            <actions>
-                <action type="format">
-                    <option type="from_param" name="output_datatype" />
-                 </action>
-           </actions>
-       </data>
+        <data name="output" format_source="input" label="${tool.name} on ${on_string}"/>
     </outputs>
     <tests>
         <test>
@@ -68,13 +96,8 @@
         </test>
     </tests>
     <help>
-.. class:: warningmark
 
-This tool works on binary images, so other image types will automatically be converted to binary
-before they are analyzed.  This step is performed using the ImageJ2 **Make Binary** command with
-the following settings: **Iterations:** 1, **Count:** 1, **Black background:** No, **Pad edges when
-eroding:** No.  If these settings are not appropriate, first manually convert the image to binary
-using the **Convert to binary (black and white) with ImageJ2** tool, which allows you to change them.
+@requires_binary_input@
 
 **What it does**
 

--- a/tools/image_processing/imagej2/imagej2_adjust_threshold_binary/jython_script.py
+++ b/tools/image_processing/imagej2/imagej2_adjust_threshold_binary/jython_script.py
@@ -1,7 +1,6 @@
 import jython_utils
 import sys
 from ij import IJ
-from ij import ImagePlus
 
 # Fiji Jython interpreter implements Python 2.5 which does not
 # provide support for argparse.

--- a/tools/image_processing/imagej2/imagej2_analyze_particles_binary/imagej2_analyze_particles_binary.xml
+++ b/tools/image_processing/imagej2/imagej2_analyze_particles_binary/imagej2_analyze_particles_binary.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<tool id="imagej2_analyze_particles_binary" name="Analyze particles" version="1.0.0">
+<tool id="imagej2_analyze_particles_binary" name="Analyze particles" version="@WRAPPER_VERSION@.0">
     <description>of binary image with ImageJ2</description>
     <macros>
         <import>imagej2_macros.xml</import>
     </macros>
-    <expand macro="fiji_20141125_requirements" />
+    <expand macro="fiji_requirements" />
     <command>
 <![CDATA[
     python $__tool_directory__/imagej2_analyze_particles_binary.py
@@ -100,11 +100,7 @@
     <help>
 .. class:: warningmark
 
-This tool works on binary images, so other image types will automatically be converted to binary
-before they are analyzed.  This step is performed using the ImageJ2 **Make Binary** command with
-the following settings: **Iterations:** 1, **Count:** 1, **Black background:** No, **Pad edges when
-eroding:** No.  If these settings are not appropriate, first manually convert the image to binary
-using the **Convert to binary (black and white) with ImageJ2** tool, which allows you to change them.
+@requires_binary_input@
 
 **What it does**
 

--- a/tools/image_processing/imagej2/imagej2_analyze_skeleton/imagej2_analyze_skeleton.xml
+++ b/tools/image_processing/imagej2/imagej2_analyze_skeleton/imagej2_analyze_skeleton.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<tool id="imagej2_analyze_skeleton" name="Analyze skeleton" version="1.0.0">
+<tool id="imagej2_analyze_skeleton" name="Analyze skeleton" version="@WRAPPER_VERSION@.0">
     <description>with ImageJ2</description>
     <macros>
         <import>imagej2_macros.xml</import>
     </macros>
-    <expand macro="fiji_20141125_requirements" />
+    <expand macro="fiji_requirements" />
     <command>
 <![CDATA[
     python $__tool_directory__/imagej2_analyze_skeleton.py

--- a/tools/image_processing/imagej2/imagej2_analyze_skeleton/jython_script.py
+++ b/tools/image_processing/imagej2/imagej2_analyze_skeleton/jython_script.py
@@ -2,7 +2,6 @@ import jython_utils
 import math
 import sys
 from ij import IJ
-from ij import ImagePlus
 from skeleton_analysis import AnalyzeSkeleton_
 
 BASIC_NAMES = [ 'Branches', 'Junctions', 'End-point Voxels',

--- a/tools/image_processing/imagej2/imagej2_bunwarpj_adapt_transform/imagej2_bunwarpj_adapt_transform.xml
+++ b/tools/image_processing/imagej2/imagej2_bunwarpj_adapt_transform/imagej2_bunwarpj_adapt_transform.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<tool id="imagej2_bunwarpj_adapt_transform" name="Adapt an elastic transformation" version="1.0.0">
+<tool id="imagej2_bunwarpj_adapt_transform" name="Adapt an elastic transformation" version="@WRAPPER_VERSION@.0">
     <description>to a new image size with bUnwarpJ</description>
     <macros>
         <import>imagej2_macros.xml</import>
     </macros>
-    <expand macro="fiji_20141125_requirements" />
+    <expand macro="fiji_requirements" />
     <command>
 <![CDATA[
     python $__tool_directory__/imagej2_bunwarpj_adapt_transform.py

--- a/tools/image_processing/imagej2/imagej2_bunwarpj_align/imagej2_bunwarpj_align.xml
+++ b/tools/image_processing/imagej2/imagej2_bunwarpj_align/imagej2_bunwarpj_align.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<tool id="imagej2_bunwarpj_align" name="Align two images" version="1.0.0">
+<tool id="imagej2_bunwarpj_align" name="Align two images" version="@WRAPPER_VERSION@.0">
     <description>with bUnwarpJ</description>
     <macros>
         <import>imagej2_macros.xml</import>
     </macros>
-    <expand macro="fiji_20141125_requirements" />
+    <expand macro="fiji_requirements" />
     <command>
 <![CDATA[
     python $__tool_directory__/imagej2_bunwarpj_align.py

--- a/tools/image_processing/imagej2/imagej2_bunwarpj_compare_elastic/imagej2_bunwarpj_compare_elastic.xml
+++ b/tools/image_processing/imagej2/imagej2_bunwarpj_compare_elastic/imagej2_bunwarpj_compare_elastic.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<tool id="imagej2_bunwarpj_compare_elastic" name="Compare opposite elastic deformations" version="1.0.0">
+<tool id="imagej2_bunwarpj_compare_elastic" name="Compare opposite elastic deformations" version="@WRAPPER_VERSION@.0">
     <description>by warping index with bUnwarpJ</description>
     <macros>
         <import>imagej2_macros.xml</import>
     </macros>
-    <expand macro="fiji_20141125_requirements" />
+    <expand macro="fiji_requirements" />
     <command>
 <![CDATA[
     python $__tool_directory__/imagej2_bunwarpj_compare_elastic.py

--- a/tools/image_processing/imagej2/imagej2_bunwarpj_compare_elastic_raw/imagej2_bunwarpj_compare_elastic_raw.xml
+++ b/tools/image_processing/imagej2/imagej2_bunwarpj_compare_elastic_raw/imagej2_bunwarpj_compare_elastic_raw.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<tool id="imagej2_bunwarpj_compare_elastic_raw" name="Compare elastic and raw deformation" version="1.0.0">
+<tool id="imagej2_bunwarpj_compare_elastic_raw" name="Compare elastic and raw deformation" version="@WRAPPER_VERSION@.0">
     <description>by warping index with bUnwarpJ</description>
     <macros>
         <import>imagej2_macros.xml</import>
     </macros>
-    <expand macro="fiji_20141125_requirements" />
+    <expand macro="fiji_requirements" />
     <command>
 <![CDATA[
     python $__tool_directory__/imagej2_bunwarpj_compare_elastic_raw.py

--- a/tools/image_processing/imagej2/imagej2_bunwarpj_compare_raw/imagej2_bunwarpj_compare_raw.xml
+++ b/tools/image_processing/imagej2/imagej2_bunwarpj_compare_raw/imagej2_bunwarpj_compare_raw.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<tool id="imagej2_bunwarpj_compare_raw" name="Compare two raw deformations" version="1.0.0">
+<tool id="imagej2_bunwarpj_compare_raw" name="Compare two raw deformations" version="@WRAPPER_VERSION@.0">
     <description>by warping index with bUnwarpJ</description>
     <macros>
         <import>imagej2_macros.xml</import>
     </macros>
-    <expand macro="fiji_20141125_requirements" />
+    <expand macro="fiji_requirements" />
     <command>
 <![CDATA[
     python $__tool_directory__/imagej2_bunwarpj_compare_raw.py

--- a/tools/image_processing/imagej2/imagej2_bunwarpj_compose_elastic/imagej2_bunwarpj_compose_elastic.xml
+++ b/tools/image_processing/imagej2/imagej2_bunwarpj_compose_elastic/imagej2_bunwarpj_compose_elastic.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<tool id="imagej2_bunwarpj_compose_elastic" name="Compose two elastic transformations" version="1.0.0">
+<tool id="imagej2_bunwarpj_compose_elastic" name="Compose two elastic transformations" version="@WRAPPER_VERSION@.0">
     <description>into a raw transformation with bUnwarpJ</description>
     <macros>
         <import>imagej2_macros.xml</import>
     </macros>
-    <expand macro="fiji_20141125_requirements" />
+    <expand macro="fiji_requirements" />
     <command>
 <![CDATA[
     python $__tool_directory__/imagej2_bunwarpj_compose_elastic.py

--- a/tools/image_processing/imagej2/imagej2_bunwarpj_compose_raw/imagej2_bunwarpj_compose_raw.xml
+++ b/tools/image_processing/imagej2/imagej2_bunwarpj_compose_raw/imagej2_bunwarpj_compose_raw.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<tool id="imagej2_bunwarpj_compose_raw" name="Compose two raw transformations" version="1.0.0">
+<tool id="imagej2_bunwarpj_compose_raw" name="Compose two raw transformations" version="@WRAPPER_VERSION@.0">
     <description>into another raw transformation with bUnwarpJ</description>
     <macros>
         <import>imagej2_macros.xml</import>
     </macros>
-    <expand macro="fiji_20141125_requirements" />
+    <expand macro="fiji_requirements" />
     <command>
 <![CDATA[
     python $__tool_directory__/imagej2_bunwarpj_compose_raw.py

--- a/tools/image_processing/imagej2/imagej2_bunwarpj_compose_raw_elastic/imagej2_bunwarpj_compose_raw_elastic.xml
+++ b/tools/image_processing/imagej2/imagej2_bunwarpj_compose_raw_elastic/imagej2_bunwarpj_compose_raw_elastic.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<tool id="imagej2_bunwarpj_compose_raw_elastic" name="Compose a raw and an elastic transformation" version="1.0.0">
+<tool id="imagej2_bunwarpj_compose_raw_elastic" name="Compose a raw and an elastic transformation" version="@WRAPPER_VERSION@.0">
     <description>into a raw transformation with bUnwarpJ</description>
     <macros>
         <import>imagej2_macros.xml</import>
     </macros>
-    <expand macro="fiji_20141125_requirements" />
+    <expand macro="fiji_requirements" />
     <command>
 <![CDATA[
     python $__tool_directory__/imagej2_bunwarpj_compose_raw_elastic.py

--- a/tools/image_processing/imagej2/imagej2_bunwarpj_convert_to_raw/imagej2_bunwarpj_convert_to_raw.xml
+++ b/tools/image_processing/imagej2/imagej2_bunwarpj_convert_to_raw/imagej2_bunwarpj_convert_to_raw.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<tool id="imagej2_bunwarpj_convert_to_raw" name="Convert elastic transformation to raw" version="1.0.0">
+<tool id="imagej2_bunwarpj_convert_to_raw" name="Convert elastic transformation to raw" version="@WRAPPER_VERSION@.0">
     <description>with bUnwarpJ</description>
     <macros>
         <import>imagej2_macros.xml</import>
     </macros>
-    <expand macro="fiji_20141125_requirements" />
+    <expand macro="fiji_requirements" />
     <command>
 <![CDATA[
     python $__tool_directory__/imagej2_bunwarpj_convert_to_raw.py

--- a/tools/image_processing/imagej2/imagej2_bunwarpj_elastic_transform/imagej2_bunwarpj_elastic_transform.xml
+++ b/tools/image_processing/imagej2/imagej2_bunwarpj_elastic_transform/imagej2_bunwarpj_elastic_transform.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<tool id="imagej2_bunwarpj_elastic_transform" name="Apply elastic transformation" version="1.0.0">
+<tool id="imagej2_bunwarpj_elastic_transform" name="Apply elastic transformation" version="@WRAPPER_VERSION@.0">
     <description>with bUnwarpJ</description>
     <macros>
         <import>imagej2_macros.xml</import>
     </macros>
-    <expand macro="fiji_20141125_requirements" />
+    <expand macro="fiji_requirements" />
     <command>
 <![CDATA[
     python $__tool_directory__/imagej2_bunwarpj_elastic_transform.py

--- a/tools/image_processing/imagej2/imagej2_bunwarpj_raw_transform/imagej2_bunwarpj_raw_transform.xml
+++ b/tools/image_processing/imagej2/imagej2_bunwarpj_raw_transform/imagej2_bunwarpj_raw_transform.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<tool id="imagej2_bunwarpj_raw_transform" name="Apply raw transformation" version="1.0.0">
+<tool id="imagej2_bunwarpj_raw_transform" name="Apply raw transformation" version="@WRAPPER_VERSION@.0">
     <description>with bUnwarpJ</description>
     <macros>
         <import>imagej2_macros.xml</import>
     </macros>
-    <expand macro="fiji_20141125_requirements" />
+    <expand macro="fiji_requirements" />
     <command>
 <![CDATA[
     python $__tool_directory__/imagej2_bunwarpj_raw_transform.py

--- a/tools/image_processing/imagej2/imagej2_convert_format/imagej2_convert_format.xml
+++ b/tools/image_processing/imagej2/imagej2_convert_format/imagej2_convert_format.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<tool id="imagej2_convert_format" name="Convert image format" version="1.0.0">
+<tool id="imagej2_convert_format" name="Convert image format" version="@WRAPPER_VERSION@.0">
     <description>with bioformats</description>
     <macros>
         <import>imagej2_macros.xml</import>
     </macros>
-    <expand macro="python_bioformats_104_requirements" />
+    <expand macro="python_bioformats_requirements" />
     <command interpreter="python">
 <![CDATA[
         imagej2_convert_format.py

--- a/tools/image_processing/imagej2/imagej2_create_image/imagej2_create_image.xml
+++ b/tools/image_processing/imagej2/imagej2_create_image/imagej2_create_image.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<tool id="imagej2_create_image" name="Create new image" version="1.0.0">
+<tool id="imagej2_create_image" name="Create new image" version="@WRAPPER_VERSION@.0">
     <description>with ImageJ2</description>
     <macros>
         <import>imagej2_macros.xml</import>
     </macros>
-    <expand macro="fiji_20141125_requirements" />
+    <expand macro="fiji_requirements" />
     <command>
 <![CDATA[
     python $__tool_directory__/imagej2_create_image.py

--- a/tools/image_processing/imagej2/imagej2_macros.xml
+++ b/tools/image_processing/imagej2/imagej2_macros.xml
@@ -1,11 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <macros>
-    <xml name="fiji_20141125_requirements">
+    <token name="@WRAPPER_VERSION@">1.0</token>
+    <xml name="fiji_requirements">
         <requirements>
             <requirement type="package" version="20141125">fiji</requirement>
         </requirements>
     </xml>
-    <xml name="python_bioformats_104_requirements">
+    <xml name="python_bioformats_requirements">
         <requirements>
             <requirement type="package" version="20141125">fiji</requirement>
             <requirement type="package" version="1.0.11">javabridge</requirement>
@@ -59,49 +60,15 @@
         --black_background $black_background
         --pad_edges_when_eroding $pad_edges_when_eroding
     </token>
-    <token name="@adjust_threshold_binary_args@">
-        --threshold_min $threshold_min
-        --threshold_max $threshold_max
-        --method $method
-        --display $display
-        --dark_background $dark_background
-        --stack_histogram $stack_histogram
+    <token name="@requires_binary_input@">
+.. class:: warningmark
+
+This tool works on binary images, so other image types will automatically be converted to binary
+before they are analyzed.  This step is performed using the ImageJ2 **Make Binary** command with
+the following settings: **Iterations:** 1, **Count:** 1, **Black background:** No, **Pad edges when
+eroding:** No.  If these settings are not appropriate, first manually convert the image to binary
+using the **Convert to binary (black and white) with ImageJ2** tool, which allows you to change them.
     </token>
-    <xml name="adjust_threshold_binary_params">
-        <param name="threshold_min" type="float" value="0" min="0" max="255" label="Minimum threshold value" />
-        <param name="threshold_max" type="float" value="0" min="0" max="255" label="Maximum threshold value" />
-        <param name="method" type="select" label="Method" help="The Default method is the modified IsoData algorithm.">
-            <option value="Default" selected="True">Default</option>
-            <option value="Huang">Huang</option>
-            <option value="Intermodes">Intermodes</option>
-            <option value="IsoData">IsoData</option>
-            <option value="IJ_IsoData">IJ_IsoData</option>
-            <option value="Li">Li</option>
-            <option value="MaxEntropy">MaxEntropy</option>
-            <option value="Mean">Mean</option>
-            <option value="MinError">MinError</option>
-            <option value="Minimum">Minimum</option>
-            <option value="Moments">Moments</option>
-            <option value="Otsu">Otsu</option>
-            <option value="RenyiEntropy">RenyiEntropy</option>
-            <option value="Shanbhag">Shanbhag</option>
-            <option value="Triangle">Triangle</option>
-            <option value="Yen">Yen</option>
-        </param>
-        <param name="display" type="select" label="Display">
-            <option value="red" selected="True">Red</option>
-            <option value="bw">Black and White</option>
-            <option value="over_under">Over/Under</option>
-        </param>
-        <param name="dark_background" type="select" label="Dark background" help="Select yes if features are lighter than the background.">
-            <option value="no" selected="True">No</option>
-            <option value="yes">Yes</option>
-        </param>
-        <param name="stack_histogram" type="select" label="Stack histogram" help="Select yes to first compute the histogram of the whole stack (or hyperstack) and then compute the threshold based on that histogram.">
-            <option value="no" selected="True">No</option>
-            <option value="yes">Yes</option>
-        </param>
-    </xml>
     <xml name="image_datatypes">
         <option value="bmp">bmp</option>
         <option value="gif">gif</option>

--- a/tools/image_processing/imagej2/imagej2_make_binary/imagej2_make_binary.xml
+++ b/tools/image_processing/imagej2/imagej2_make_binary/imagej2_make_binary.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<tool id="imagej2_make_binary" name="Convert to binary" version="1.0.0">
+<tool id="imagej2_make_binary" name="Convert to binary" version="@WRAPPER_VERSION@.0">
     <description>(black and white) with ImageJ2</description>
     <macros>
         <import>imagej2_macros.xml</import>
     </macros>
-    <expand macro="fiji_20141125_requirements" />
+    <expand macro="fiji_requirements" />
     <command>
 <![CDATA[
     python $__tool_directory__/imagej2_make_binary.py
@@ -12,25 +12,16 @@
     --input_datatype $input.ext
     @make_binary_args@
     --jython_script $__tool_directory__/jython_script.py
-    --output_datatype $output_datatype
+    --output_datatype $output.ext
     --output "$output"
 ]]>
     </command>
     <inputs>
         <param format="bmp,eps,gif,jpg,pcx,pgm,png,psd,tiff" name="input" type="data" label="Select image"/>
         <expand macro="make_binary_params" />
-        <param name="output_datatype" type="select" label="Save as format">
-            <expand macro="image_datatypes" />
-        </param>
     </inputs>
     <outputs>
-        <data name="output" format_source="input" label="${tool.name} on ${on_string}">
-            <actions>
-                <action type="format">
-                    <option type="from_param" name="output_datatype" />
-                 </action>
-           </actions>
-       </data>
+        <data name="output" format_source="input" label="${tool.name} on ${on_string}"/>
     </outputs>
     <tests>
         <test>

--- a/tools/image_processing/imagej2/imagej2_make_binary/jython_script.py
+++ b/tools/image_processing/imagej2/imagej2_make_binary/jython_script.py
@@ -1,7 +1,6 @@
 import jython_utils
 import sys
 from ij import IJ
-from ij import ImagePlus
 
 # Fiji Jython interpreter implements Python 2.5 which does not
 # provide support for argparse.

--- a/tools/image_processing/imagej2/imagej2_noise/imagej2_noise.xml
+++ b/tools/image_processing/imagej2/imagej2_noise/imagej2_noise.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<tool id="imagej2_noise" name="Add or remove noise" version="1.0.0">
+<tool id="imagej2_noise" name="Add or remove noise" version="@WRAPPER_VERSION@.0">
     <description>with ImageJ2</description>
     <macros>
         <import>imagej2_macros.xml</import>
@@ -10,7 +10,7 @@
             </param>
         </xml>
     </macros>
-    <expand macro="fiji_20141125_requirements" />
+    <expand macro="fiji_requirements" />
     <command>
 <![CDATA[
     python $__tool_directory__/imagej2_noise.py

--- a/tools/image_processing/imagej2/imagej2_skeletonize3d/imagej2_skeletonize3d.xml
+++ b/tools/image_processing/imagej2/imagej2_skeletonize3d/imagej2_skeletonize3d.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<tool id="imagej2_skeletonize3d" name="Skeletonize images" version="1.0.0">
+<tool id="imagej2_skeletonize3d" name="Skeletonize images" version="@WRAPPER_VERSION@.0">
     <description>with ImageJ2</description>
     <macros>
         <import>imagej2_macros.xml</import>
     </macros>
-    <expand macro="fiji_20141125_requirements" />
+    <expand macro="fiji_requirements" />
     <command>
 <![CDATA[
     python $__tool_directory__/imagej2_skeletonize3d.py
@@ -12,23 +12,14 @@
     --input_datatype $input.ext
     --jython_script $__tool_directory__/jython_script.py
     --output "$output"
-    --output_datatype $output_datatype
+    --output_datatype $output.ext
 ]]>
     </command>
     <inputs>
         <param format="bmp,eps,gif,jpg,pcx,pgm,png,psd,tiff" name="input" type="data" label="Select grayscale image"/>
-        <param name="output_datatype" type="select" label="Save as format">
-            <expand macro="image_datatypes" />
-        </param>
     </inputs>
     <outputs>
-        <data name="output" format_source="input" label="${tool.name} on ${on_string}">
-            <actions>
-                <action type="format">
-                    <option type="from_param" name="output_datatype" />
-                 </action>
-           </actions>
-       </data>
+        <data name="output" format_source="input" label="${tool.name} on ${on_string}"/>
     </outputs>
     <tests>
         <test>

--- a/tools/image_processing/imagej2/imagej2_skeletonize3d/jython_script.py
+++ b/tools/image_processing/imagej2/imagej2_skeletonize3d/jython_script.py
@@ -1,7 +1,6 @@
 import jython_utils
 import sys
 from ij import IJ
-from ij import ImagePlus
 
 # Fiji Jython interpreter implements Python 2.5 which does not
 # provide support for argparse.

--- a/tools/image_processing/imagej2/imagej2_watershed_binary/imagej2_watershed_binary.xml
+++ b/tools/image_processing/imagej2/imagej2_watershed_binary/imagej2_watershed_binary.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<tool id="imagej2_watershed_binary" name="Watershed segmentation" version="1.0.0">
+<tool id="imagej2_watershed_binary" name="Watershed segmentation" version="@WRAPPER_VERSION@.0">
     <description>of binary image with ImageJ2</description>
     <macros>
         <import>imagej2_macros.xml</import>
     </macros>
-    <expand macro="fiji_20141125_requirements" />
+    <expand macro="fiji_requirements" />
     <command>
 <![CDATA[
     python $__tool_directory__/imagej2_watershed_binary.py
@@ -30,11 +30,7 @@
     <help>
 .. class:: warningmark
 
-This tool works on binary images, so other image types will automatically be converted to binary
-before they are analyzed.  This step is performed using the ImageJ2 **Make Binary** command with
-the following settings: **Iterations:** 1, **Count:** 1, **Black background:** No, **Pad edges when
-eroding:** No.  If these settings are not appropriate, first manually convert the image to binary
-using the **Convert to binary (black and white) with ImageJ2** tool, which allows you to change them.
+@requires_binary_input@
 
 **What it does**
 


### PR DESCRIPTION
1) Eliminate unnecessary imports from some Jython scripts
2) Make tool version string a macro
3) Eliminate version string from fiji and bioformats macro requirements
4) Move alert text for tools that require binary image inputs to a macro
5) Eliminate the ability to set output image formats - outputs will have
the same format as inputs
6) Move the adjust threshold command line arguments and parameters from
the macros to the tool config - I originally thought I may use these
across tools, but have since determined that is not needed.