### PR TITLE
Have tp_split_on_column use a tmp directory for output. 

### DIFF
--- a/tools/text_processing/split_file_on_column/split_file_on_column.xml
+++ b/tools/text_processing/split_file_on_column/split_file_on_column.xml
@@ -5,7 +5,8 @@
     </requirements>
     <command>
 <![CDATA[
-        awk -F'\t' '{print > \$$column ".$infile.ext" }' $infile
+        mkdir tmp_out &&
+        awk -F'\t' '{print > "tmp_out/"\$$column".$infile.ext" }' $infile
 ]]>
     </command>
     <inputs>
@@ -14,7 +15,7 @@
     </inputs>
     <outputs>
         <collection name="split_output" type="list" label="Table split on first column">
-            <discover_datasets pattern="__name_and_ext__" directory="." />
+            <discover_datasets pattern="__name_and_ext__" directory="tmp_out" />
         </collection>
     </outputs>
     <!--outputs>


### PR DESCRIPTION
Prevents other cruft in the job directory from being included in the collection list.