### PR TITLE
Sortmerna

### DIFF
--- a/.tt_blacklist
+++ b/.tt_blacklist
@@ -21,7 +21,6 @@ tools/rna_tools/rnabob
 tools/rna_tools/dotknot
 tools/rna_tools/targetfinder
 tools/rna_tools/reago
-tools/rna_tools/sortmerna
 tools/rna_tools/antarna
 tools/rna_tools/miRDeep2/miRDeep2_mapper
 tools/rna_tools/miRDeep2/miRDeep2_quantifier

--- a/tools/rna_tools/sortmerna/sortmerna.xml
+++ b/tools/rna_tools/sortmerna/sortmerna.xml
@@ -1,7 +1,7 @@
-<tool id="bg_sortmerna" name="Filter with SortMeRNA" version="2.1.0">
+<tool id="bg_sortmerna" name="Filter with SortMeRNA" version="2.1b.0">
     <description>Fast and accurate filtering of ribosomal RNAs in metatranscriptomic data</description>
     <requirements>
-        <requirement type="package" version="2.0">sortmerna</requirement>
+        <requirement type="package" version="2.1b">sortmerna</requirement>
     </requirements>
     <stdio>
         <regex match="This program builds a Burst trie on an input rRNA database"

--- a/tools/rna_tools/sortmerna/sortmerna.xml
+++ b/tools/rna_tools/sortmerna/sortmerna.xml
@@ -1,7 +1,7 @@
 <tool id="bg_sortmerna" name="Filter with SortMeRNA" version="2.1.0">
     <description>Fast and accurate filtering of ribosomal RNAs in metatranscriptomic data</description>
     <requirements>
-        <requirement type='package' version="2.0">sortmerna</requirement>
+        <requirement type="package" version="2.0">sortmerna</requirement>
     </requirements>
     <stdio>
         <regex match="This program builds a Burst trie on an input rRNA database"
@@ -12,6 +12,10 @@
             source="both"
             level="fatal"
             description="The database ${databases} has not been preprocessed using buildtrie before using SortMeRNA." />
+        <regex match="ERROR"
+            source="both"
+            level="fatal"
+            description="ERROR" />
     </stdio>
     <version_command>
 <![CDATA[
@@ -76,9 +80,7 @@ sortmerna --version 2>&1|grep 'SortMeRNA version'
     	$log
 
         #if $report.report_type == 'best'
-            #if $report.report_best.report_best_type == '0'
-                --best 0
-            #else if $report.report_best.report_best_type == '1'
+            #if $report.report_best.report_best_type == '1'
                 --best 1
                 --min_lis $report.report_best.report_best_min_lis
             #else
@@ -195,11 +197,9 @@ sortmerna --version 2>&1|grep 'SortMeRNA version'
             <when value="best">
                 <conditional name="report_best">
                     <param name="report_best_type" type="select" label="Number of searched alignments" help="Only the best alignment is reported (--best)">
-                        <option value="0">All high-candidate reference sequences are searched for alignments (very slow)</option>
                         <option value="1" selected="true">Only one high-candidate reference sequence is searched for alignments (fast). The high-candidate sequences are determined heuristically using a LIS of seed matches)</option>
                         <option value="other_value">A custom number of reference sequences are searched for alignments (speed decrease for high value)</option>
                     </param>
-                    <when value="0" />
                     <when value="1">
                         <param name="report_best_min_lis" type="integer" min="0" max="100" value="2" label="Number of longest LIS an alignement needs to be searched" help="The alignements having the first INT longest LIS. LIS stands for Longest Increasing Subsequence, it is computed using seeds' positions to expand hits into longer matches prior to Smith-Waterman alignment. (--min_lis)"/>
                     </when>

--- a/tools/rna_tools/sortmerna/tool_dependencies.xml
+++ b/tools/rna_tools/sortmerna/tool_dependencies.xml
@@ -1,58 +1,48 @@
 <?xml version="1.0"?>
 <tool_dependency>
-    <package name="sortmerna" version="2.0">
+    <package name="sortmerna" version="2.1b">
         <install version="1.0">
             <actions_group>
                 <actions architecture="x86_64" os="linux">
-                        <action type="download_by_url" target_filename="sortmerna-2.0.tar.gz">https://github.com/biocore/sortmerna/archive/2.0.tar.gz</action>
-                        <action type="shell_command"><![CDATA[
-                            ./build.sh --prefix=$INSTALL_DIR
-                        ]]>
-                        </action>
-                        <action type="change_directory">../</action>
-                        <action type="make_directory">$INSTALL_DIR/bin/</action>
-                        <action type="move_file">
-                            <source>sortmerna-2.0/sortmerna</source>
-                            <destination>$INSTALL_DIR/bin</destination>
-                        </action>
-                        <action type="move_file">
-                            <source>sortmerna-2.0/indexdb_rna</source>
-                            <destination>$INSTALL_DIR/bin</destination>
-                        </action>
-                        <action type="make_directory">$INSTALL_DIR/rRNA_databases/</action>
-                        <action type="move_directory_files">
-                            <source_directory>sortmerna-2.0/rRNA_databases/</source_directory>
-                            <destination_directory>$INSTALL_DIR/rRNA_databases/</destination_directory>
-                        </action>
-                        <action type="set_environment">
-                            <environment_variable name="SORTMERNADIR" action="set_to">$INSTALL_DIR/</environment_variable>
-                            <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>
-                        </action>
-                    </actions>
+                    <action type="download_by_url" target_filename="sortmerna-2.1b.tar.gz">https://github.com/biocore/sortmerna/archive/2.1b.tar.gz</action>
+                    <action type="shell_command"><![CDATA[
+                        ./build.sh --prefix=$INSTALL_DIR
+                    ]]>
+                    </action>
+                    <action type="shell_command">make install</action>
+                    <action type="make_directory">$INSTALL_DIR/rRNA_databases/</action>
+                    <action type="move_directory_files">
+                        <source_directory>rRNA_databases/</source_directory>
+                        <destination_directory>$INSTALL_DIR/rRNA_databases/</destination_directory>
+                    </action>
+                    <action type="set_environment">
+                        <environment_variable name="SORTMERNADIR" action="set_to">$INSTALL_DIR/</environment_variable>
+                        <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>
+                    </action>
+                </actions>
                 <actions architecture="x86_64" os="darwin">
-                        <action type="download_by_url" target_filename="sortmerna-2.0.tar.gz">https://github.com/biocore/sortmerna/archive/2.0.tar.gz</action>
-                        <action type="shell_command"><![CDATA[
-                            export CC=gcc-mp-4.8 && export CXX=g++-mp-4.8 && ./configure && make && make install
-                        ]]>
-                        </action>
-                        <action type="change_directory">../</action>
-                        <action type="make_directory">$INSTALL_DIR/rRNA_databases/</action>
-                        <action type="move_directory_files">
-                            <source_directory>sortmerna-2.0/rRNA_databases/</source_directory>
-                            <destination_directory>$INSTALL_DIR/rRNA_databases/</destination_directory>
-                        </action>
-                        <action type="set_environment">
-                            <environment_variable name="SORTMERNADIR" action="set_to">$INSTALL_DIR/</environment_variable>
-                            <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>
-                        </action>                
-                    </actions>
-                </actions_group>
+                    <action type="download_by_url" target_filename="sortmerna-2.1b.tar.gz">https://github.com/biocore/sortmerna/archive/2.1b.tar.gz</action>
+                    <action type="shell_command"><![CDATA[
+                        export CC=gcc-mp-4.8 && export CXX=g++-mp-4.8 && ./build.sh --prefix=$INSTALL_DIR && make install
+                    ]]>
+                    </action>
+                    <action type="make_directory">$INSTALL_DIR/rRNA_databases/</action>
+                    <action type="move_directory_files">
+                        <source_directory>rRNA_databases/</source_directory>
+                        <destination_directory>$INSTALL_DIR/rRNA_databases/</destination_directory>
+                    </action>
+                    <action type="set_environment">
+                        <environment_variable name="SORTMERNADIR" action="set_to">$INSTALL_DIR/</environment_variable>
+                        <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>
+                    </action>
+                </actions>
+            </actions_group>
         </install>
         <readme>
-        SortMeRNA requires g++ 4.8 or later. 
+        SortMeRNA requires g++ 4.8 or later.
 
-        Note: the Clang compiler on Mac (distributed through Xcode) does not 
-        support multithreading. The user is recommended to install the original 
+        Note: the Clang compiler on Mac (distributed through Xcode) does not
+        support multithreading. The user is recommended to install the original
         GCC compiler via MacPorts
         </readme>
     </package>

--- a/tools/rna_tools/sortmerna/tool_dependencies.xml
+++ b/tools/rna_tools/sortmerna/tool_dependencies.xml
@@ -5,8 +5,20 @@
             <actions_group>
                 <actions architecture="x86_64" os="linux">
                         <action type="download_by_url" target_filename="sortmerna-2.0.tar.gz">https://github.com/biocore/sortmerna/archive/2.0.tar.gz</action>
-                        <action type="autoconf"/>
+                        <action type="shell_command"><![CDATA[
+                            ./build.sh --prefix=$INSTALL_DIR
+                        ]]>
+                        </action>
                         <action type="change_directory">../</action>
+                        <action type="make_directory">$INSTALL_DIR/bin/</action>
+                        <action type="move_file">
+                            <source>sortmerna-2.0/sortmerna</source>
+                            <destination>$INSTALL_DIR/bin</destination>
+                        </action>
+                        <action type="move_file">
+                            <source>sortmerna-2.0/indexdb_rna</source>
+                            <destination>$INSTALL_DIR/bin</destination>
+                        </action>
                         <action type="make_directory">$INSTALL_DIR/rRNA_databases/</action>
                         <action type="move_directory_files">
                             <source_directory>sortmerna-2.0/rRNA_databases/</source_directory>


### PR DESCRIPTION
Hello,

I had some installation issues for SortMeRNA on Ubuntu. 
From `INSTALLATION.log` and local investigation, these issues come from `make install` command (in french...)

```
/usr/bin/install: n'écrasera pas «/home/cidam/Documents/berenice/framework/lib/galaxy-dev/dependency_dir/sortmerna/2.0/rnateam/sortmerna/233da82dc31c/include/gumbel_params.hpp» qui vient d'être créé par «./alp/gumbel_params.hpp»
...
make[1]: *** [install-includeHEADERS] Error 1
make: *** [install-am] Error 2
```

I tested by splitting `autoconf` command into `build.sh` and then moving generated binairies inside `INSTALL_DIR`. It seems to work (no more installation issue and running wrapper).
But I'm not sure it is the best solution...

I also modified `sortmerna.xml` because of some execution errors with some parameters...

Bérénice