### PR TITLE
add RNALfoldz to vienna

### DIFF
--- a/tools/rna_tools/vienna_rna/rnalfold.xml
+++ b/tools/rna_tools/vienna_rna/rnalfold.xml
@@ -34,7 +34,7 @@
     </command>
     <inputs>
 	<param format="fasta" name="fasta_input" type="data" label="FASTA file"/>
-        <param name="span" type="integer" min="0" max="5000" value="150" label="base pair span" help="Maximal distance between two paired bases. (-L)"/>
+        <param name="span" type="integer" min="0" max="10000" value="150" label="base pair span" help="Maximal distance between two paired bases. (-L)"/>
         <param name="temperature" type="float" value="37.0" label="Temperature [°C]" help="-T"/>
         <param name="dangling" type="select" label="how to treat dangling end energies" help="-d">
             <option value="2" selected="true">unpaired bases participate in all dangling ends (2)</option>

--- a/tools/rna_tools/vienna_rna/rnalfoldz.xml
+++ b/tools/rna_tools/vienna_rna/rnalfoldz.xml
@@ -1,0 +1,96 @@
+<tool id="rnalfold" name="RNALfold" version="2.1.6.0">
+    <description>calculates locally stable secondary structures of RNA</description>
+    <expand macro="requirements" />
+    <expand macro="version_command" />
+    <expand macro="stdio" />
+    <macros>
+        <token name="@EXECUTABLE@">RNALfold</token>
+        <import>macros.xml</import>
+    </macros>
+    <command>
+<![CDATA[
+        RNALfold -L $span -T $temperature -d$dangling < $fasta_input | sed -r 's/(^[.()]*) +(\(.*\)) +(.*)/\1\t\2\t\3/' > $out_file
+        #if $varExists('$advancedOptions.noconversion')
+            #if $advancedOptions.noconversion
+                --noconv
+            #end if
+            #if $advancedOptions.gquad
+                --gquad
+            #end if
+            #if $advancedOptions.nolp
+                --noLP
+            #end if
+            #if $advancedOptions.nogu
+                --noGU
+            #end if
+            #if $advancedOptions.noclosinggu
+                --noClosingGU
+            #end if
+            #if $advancedOptions.notetra
+                --noTetra
+            #end if
+        #end if
+]]>
+    </command>
+    <inputs>
+	<param format="fasta" name="fasta_input" type="data" label="FASTA file"/>
+        <param name="span" type="integer" min="0" max="5000" value="150" label="base pair span" help="Maximal distance between two paired bases. (-L)"/>
+        <param name="temperature" type="float" value="37.0" label="Temperature [°C]" help="-T"/>
+        <param name="dangling" type="select" label="how to treat dangling end energies" help="-d">
+            <option value="2" selected="true">unpaired bases participate in all dangling ends (2)</option>
+            <option value="0">ignore dangling ends (0)</option>
+            <option value="1">unpaired bases participate in one dangling end only (1)</option>
+            <option value="3">allow coaxial stacking (3)</option>
+        </param>
+        <conditional name="advancedOptions">
+            <param name="advancedSelector" type="select"  label="advanced options">
+                <option value="basic">basic Options</option>
+                <option value="advanced">advanced Options</option>
+            </param>
+            <when value="advanced">
+                <param name="noconversion" type="boolean" checked="false" label="no conversion" help="--noconv  do not convert thymine to uracile (T -> U)."/>
+                <param name="gquad" type="boolean" checked="false" label="G Quadruplex formation" help="-g  take into account G Quadruplex formation"/>
+                <param name="nolp" type="boolean" checked="false" label="No lonely pairs" help="--noLP  don't allow lonely pairs."/>
+                <param name="nogu" type="boolean" checked="false" label="No GU pairing" help="--noGU  don't allow pairing of G and U."/>
+                <param name="noclosinggu" type="boolean" checked="false" label="No GU pairing at the ends" help="--noClosingGU  don't allow pairing of G and U at the ends of helices."/>
+                <param name="notetra" type="boolean" checked="false" label="No stabilization for loops, hairpins etc." help="--noTetra"/>
+            </when>
+        </conditional>
+    </inputs>
+    <outputs>
+        <data format="txt" name="out_file"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="fasta_input" value="rnalfold_input1.fa"/>
+            <output name="out_file" file="rnalfold_result1.txt"/>
+        </test>
+    </tests>
+    <help>
+<![CDATA[
+**RNALfold**
+
+Compute locally stable RNA secondary structure with a maximal base pair span.
+For a sequence of length n and a base pair span of L the algorithm uses only
+O(n+L*L) memory and O(n*L*L) CPU time. *Thus it is practical to "scan" very
+large genomes for short RNA structures*.
+Output consists of a list of secondary structure components of size <= L, one
+entry per line. Each output line contains the predicted local structure its
+energy in kcal/mol and the starting position of the local structure.
+
+-----
+
+**Input format**
+
+- RNALfold requires one input file in FASTA format
+
+------
+
+**Outputs**
+
+- text output with dot-bracket notation and free energies of the secondary structures
+
+]]>
+    </help>
+    <expand macro="requirements" />
+</tool>

--- a/tools/rna_tools/vienna_rna/rnalfoldz.xml
+++ b/tools/rna_tools/vienna_rna/rnalfoldz.xml
@@ -1,4 +1,4 @@
-<tool id="rnalfold" name="RNALfold" version="2.1.6.0">
+<tool id="rnalfoldz" name="RNALfoldz" version="2.1.6.0">
     <description>calculates locally stable secondary structures of RNA</description>
     <expand macro="requirements" />
     <expand macro="version_command" />
@@ -9,7 +9,7 @@
     </macros>
     <command>
 <![CDATA[
-        RNALfold -L $span -T $temperature -d$dangling < $fasta_input | sed -r 's/(^[.()]*) +(\(.*\)) +(.*)/\1\t\2\t\3/' > $out_file
+        RNALfold -L $span -T $temperature -d$dangling -z$zthresh < $fasta_input | sed -r 's/(^[.()]*) +\((.*)\) +(.*) +z= +(.*)/\1\t\2\t\3\t\4/' > $out_file
         #if $varExists('$advancedOptions.noconversion')
             #if $advancedOptions.noconversion
                 --noconv
@@ -34,7 +34,8 @@
     </command>
     <inputs>
 	<param format="fasta" name="fasta_input" type="data" label="FASTA file"/>
-        <param name="span" type="integer" min="0" max="5000" value="150" label="base pair span" help="Maximal distance between two paired bases. (-L)"/>
+        <param name="zthresh" size="6" type="float" value="0" label="threshold for z-score computation (-z)" help="-z"/>
+        <param name="span" type="integer" min="0" max="400" value="150" label="base pair span" help="Maximal distance between two paired bases. (-L)"/>
         <param name="temperature" type="float" value="37.0" label="Temperature [°C]" help="-T"/>
         <param name="dangling" type="select" label="how to treat dangling end energies" help="-d">
             <option value="2" selected="true">unpaired bases participate in all dangling ends (2)</option>
@@ -63,7 +64,7 @@
     <tests>
         <test>
             <param name="fasta_input" value="rnalfold_input1.fa"/>
-            <output name="out_file" file="rnalfold_result1.txt"/>
+            <output name="out_file" file="rnalfoldz_result1.txt"/>
         </test>
     </tests>
     <help>
@@ -76,19 +77,19 @@ O(n+L*L) memory and O(n*L*L) CPU time. *Thus it is practical to "scan" very
 large genomes for short RNA structures*.
 Output consists of a list of secondary structure components of size <= L, one
 entry per line. Each output line contains the predicted local structure its
-energy in kcal/mol and the starting position of the local structure.
+energy in kcal/mol, the starting position of the local structure and its z-score.
 
 -----
 
 **Input format**
 
-- RNALfold requires one input file in FASTA format
+- RNALfoldz requires one input file in FASTA format
 
 ------
 
 **Outputs**
 
-- text output with dot-bracket notation and free energies of the secondary structures
+- fasta-like text output. each fasta comment contains tab-separated: predicted structure in dot-bracket notation, the corresponding free energy, start position and z-score
 
 ]]>
     </help>

--- a/tools/rna_tools/vienna_rna/test-data/rnalfoldz_result1.txt
+++ b/tools/rna_tools/vienna_rna/test-data/rnalfoldz_result1.txt
@@ -1,0 +1,9 @@
+>Anolis_carolinensis_chrUn_GL343590.trna2-AlaAGC (218800-218872)  Ala (AGC) 73 bp  Sc: 49.55
+.((((((..((((........)))).(((((.......))))).....(((((.......))))))))))).	-22.00	1	-1.43
+UGGGAAUUAGCUCAAAUGGUAGAGCGCUCGCUUAGCAUGUGAGAGGUAGUGGGAUCGAUGCCCACAUUCUCCA
+ (-22.00)
+>Anolis_carolinensis_chrUn_GL343207.trna3-AlaAGC (1513626-1513698)  Ala (AGC) 73 bp  Sc: 56.15
+.(((.(((((.(((((.......)))))..)).(((((.......)))))..))))))	-20.00	16	-1.51
+(((((((..((((........)))).(((((.......))))).....(((((.......)))))))))))).	-29.60	1	-3.30
+GGGGAAUUAGCUCAAAUGGUAGAGCGCUCGCUUAGCAUGCGAGAGGUAGCGGGAUUGAUGCCCGCAUUCUCCA
+ (-29.60)


### PR DESCRIPTION
* RNALfoldz is RNALfold with -z option set
* created a separate tool because:
  * output format changes
  * the maximum span is 400 compared to 5000 of RNALfold
  * has additional citation

* bonus:
  * 5000 is actually not a sufficient maximum for RNALfold, changed to 10k

not sure how to add the citation in combination with the one already there via macro.xml, should add

```
Gruber, A. R., Bernhart, S. H., Zhou, Y. & Hofacker, I. L. RNALfoldz: efficient prediction of thermodynamically stable, local secondary structures. GI-Edition Lecture No in Informat 12 (2010).
```