### PR TITLE
Trim Galore! modifications for gzipped file handling

### DIFF
--- a/tools/trim_galore/trim_galore.xml
+++ b/tools/trim_galore/trim_galore.xml
@@ -48,8 +48,8 @@
         <requirement type="package" version="1.8.3">cutadapt</requirement>
         <requirement type="package" version="1.8">cutadapt</requirement>
     </requirements>
-    <version_command>
-        perl $__tool_directory/trim_galore --version
+    <version_command interpreter="perl">
+        $__tool_directory/trim_galore --version
     </version_command>
     <command>
 <![CDATA[
@@ -60,7 +60,7 @@
         ## We work around this by linking every file to cwd without file extension
 
         #if $singlePaired.sPaired == "single":
-            #if str($singlePaired.input_single).endswith(".gz"):
+            #if str($singlePaired.input_singles).endswith(".gz"):
                 ln -s "${singlePaired.input_singles}" ./input_singles.gz;
             #else
                 ln -s "${singlePaired.input_singles}" ./input_singles;
@@ -147,9 +147,9 @@
 
         #if $singlePaired.sPaired == "single":
             ## input sequence
-            #if str($singlePaired.input_single).endswith(".gz"):
-                --dont_gzip
+            #if str($singlePaired.input_singles).endswith(".gz"):
                 ./input_singles.gz
+                --dont_gzip
             #else
                 ./input_singles
             #end if
@@ -171,18 +171,18 @@
             ## input sequences
             #if $singlePaired.sPaired == "paired":
                 #if str($singlePaired.input_mate1).endswith(".gz"):
-                    --dont_gzip
                     ./input_mate1.gz
                     ./input_mate2.gz
+                    --dont_gzip
                 #else
                     ./input_mate1
                     ./input_mate2
                 #end if
             #else:
                 #if str($singlePaired.input_mate_pairs.forward).endswith(".gz"):
-                    --dont_gzip
                     ./input_mate1.gz
                     ./input_mate2.gz
+                    --dont_gzip
                 #else
                     ./input_mate1
                     ./input_mate2
@@ -190,6 +190,18 @@
             #end if
 
         #end if
+
+        ##  Trim Galore is finished, rename the output if compressed
+        &&
+        if [ -f input_singles.gz_trimmed.fq ] ; then mv input_singles.gz_trimmed.fq input_singles_trimmed.fq ; fi
+        &&
+        if [ -f input_mate1.gz_val_1.fq ] ; then mv input_mate1.gz_val_1.fq input_mate1_val_1.fq ; fi
+        &&
+        if [ -f input_mate2.gz_val_2.fq ] ; then mv input_mate2.gz_val_2.fq input_mate2_val_2.fq ; fi
+        &&
+        if [ -f input_mate1.gz_unpaired_1.fq ] ; then mv input_mate1.gz_unpaired_1.fq input_mate1_unpaired_1.fq ; fi
+        &&
+        if [ -f input_mate2.gz_unpaired_2.fq ] ; then mv input_mate2.gz_unpaired_2.fq input_mate2_unpaired_2.fq ; fi
 
         ##  Trim Galore! run is finished. Move the report files to the proper place
         #if $params.settingsType == "custom" and $params.report:


### PR DESCRIPTION
This is still a bit hacky, but I've tested SE/PE/PE collections with both compressed and uncompressed files locally and everything seems to work. I guess if/when Galaxy starts supporting gzipped fastq files innately that a lot of scripts will need to start doing stuff like this.