### PR TITLE
Eliminate unnecessary env vars

### DIFF
--- a/tools/image_processing/imagej2/imagej2_base_utils.py
+++ b/tools/image_processing/imagej2/imagej2_base_utils.py
@@ -3,11 +3,6 @@ import shutil
 import sys
 import tempfile
 
-FIJI_JAR_DIR = os.environ.get('FIJI_JAR_DIR', None)
-FIJI_OSX_JAVA3D_DIR = os.environ.get('FIJI_OSX_JAVA3D_DIR', None)
-FIJI_PLUGIN_DIR = os.environ.get('FIJI_PLUGIN_DIR', None)
-FIJI_ROOT_DIR = os.environ.get('FIJI_ROOT_DIR', None)
-
 BUFF_SIZE = 1048576
 
 
@@ -20,16 +15,17 @@ def cleanup_before_exit(tmp_dir):
 
 
 def get_base_cmd_bunwarpj(jvm_memory):
-    if FIJI_JAR_DIR is not None and FIJI_PLUGIN_DIR is not None:
-        if jvm_memory in [None, 'None']:
-            jvm_memory_str = ''
-        else:
-            jvm_memory_str = '-Xmx%s' % jvm_memory
-        # bunwarpj_base_cmd = "java %s -cp %s/ij-1.49k.jar:%s/bUnwarpJ_-2.6.1.jar bunwarpj.bUnwarpJ_" % \
-        #    (jvm_memory_str, FIJI_JAR_DIR, FIJI_PLUGIN_DIR)
-        bunwarpj_base_cmd = "bunwarpj %s" % jvm_memory_str
-        return bunwarpj_base_cmd
-    return None
+    if jvm_memory in [None, 'None']:
+        jvm_memory_str = ''
+    else:
+        jvm_memory_str = '-Xmx%s' % jvm_memory
+    # The following bunwarpj_base_cmd string will look something like this:
+    # "java %s -cp $JAR_DIR/ij-1.49k.jar:$PLUGINS_DIR/bUnwarpJ_-2.6.1.jar \
+    # bunwarpj.bUnwarpJ_" % (jvm_memory_str)
+    # See the bunwarpj.sh script for the fiji 20151222
+    # bioconda recipe in github.
+    bunwarpj_base_cmd = "bunwarpj %s" % jvm_memory_str
+    return bunwarpj_base_cmd
 
 
 def get_base_command_imagej2(memory_size=None, macro=None, jython_script=None):


### PR DESCRIPTION
No longer necessary since the introduction of the 20151222 conda install recipe for Fiji here https://github.com/bioconda/bioconda-recipes/blob/master/recipes/fiji/20151222/bunwarpj.sh