### PR TITLE
fixed bug when using cached transcriptome

### DIFF
--- a/tools/salmon/salmon.xml
+++ b/tools/salmon/salmon.xml
@@ -28,8 +28,8 @@
         mkdir ./index
         &&
         mkdir ./output
-        &&
         #if $refTranscriptSource.TranscriptSource == "history":
+            &&
             salmon index
                 --transcripts $refTranscriptSource.ownFile
                 --kmerLen $refTranscriptSource.kmerLen


### PR DESCRIPTION
Location of an '&&' in the <command> block followed by an optional indexing command causes an error if the indexing command is not called (using cached transcriptome) because two '&&' end up adjacent. Moving the first one inside the if block fixes this.