### PR TITLE
Option to skip ps drawing in rnafold

### DIFF
--- a/tools/rna_tools/vienna_rna/rnafold.xml
+++ b/tools/rna_tools/vienna_rna/rnafold.xml
@@ -1,4 +1,4 @@
-<tool id="viennarna_rnafold" name="@EXECUTABLE@" version="@VERSION@.1">
+<tool id="viennarna_rnafold" name="@EXECUTABLE@" version="@VERSION@.2">
     <description>Calculate minimum free energy secondary structures and partition function of RNAs</description>
     <macros>
         <token name="@EXECUTABLE@">RNAfold</token>

--- a/tools/rna_tools/vienna_rna/rnafold.xml
+++ b/tools/rna_tools/vienna_rna/rnafold.xml
@@ -149,7 +149,7 @@
             </when>
         </conditional>
         <section name="advancedOptions" title="Advanced options">
-            <param name="nops" type="boolean" truevalue="" falsevalue="--noPS" checked="true" label="Do not produce postscript drawing of the mfe structure (reduces run-time)" help="(--noPS)"/>
+            <param name="nops" type="boolean" truevalue="--noPS" falsevalue="" checked="false" label="Do not produce postscript drawing of the mfe structure (reduces run-time)" help="(--noPS)"/>
             <param name="nolp" type="boolean" truevalue="" falsevalue="--noLP" checked="true" label="Allow lonely base-pairs" help="(--noLP)"/>
             <param name="nogu" type="boolean" truevalue="" falsevalue="--noGU" checked="true" label="Allow GU pairing" help="--noGU"/>
             <param name="noclosinggu" type="boolean" truevalue="" falsevalue="--noClosingGU" checked="true" label="Allow GU pairing at the ends" help="Allow pairing of G and U at the ends of helices. --noClosingGU"/>
@@ -216,7 +216,7 @@
                             <option value="notUsed" selected="true">Don't use shape reactivity data</option>
                         </param>
                         <when value ="isUsed">
-                            <param type="data" name="shapeFile" format="shape,*" label="Shape file" argument="--shape"/>
+                            <param type="data" name="shapeFile" format="txt" label="Shape file" argument="--shape"/>
                             <conditional name="shapeMethod">
                                 <param name="methodSelector" type="select" label="Shape reactivity data" argument="--shapeMethod">
                                     <option value="D" selected="true">D: Convert by using a linear equation according to Deigan et al 2009</option>
@@ -289,6 +289,7 @@
     <outputs>
         <data format="dbn" name="tabular_file"/>
         <collection name="sequence_outputs" type="list" label="rna_eps outputs">
+            <filter>advancedOptions['nops'] is False</filter>
             <discover_datasets pattern="(?P&lt;designation&gt;.+)_ss\.ps" ext="eps" />
         </collection>
         <collection name="matrix_outputs" type="list" label="rna_eps outputs">

--- a/tools/rna_tools/vienna_rna/rnafold.xml
+++ b/tools/rna_tools/vienna_rna/rnafold.xml
@@ -45,6 +45,7 @@
     $advancedOptions.noconversion
     $advancedOptions.gquad
     $advancedOptions.nolp
+    $advancedOptions.nops
     $advancedOptions.nogu
     $advancedOptions.noclosinggu
     $advancedOptions.notetra
@@ -148,6 +149,7 @@
             </when>
         </conditional>
         <section name="advancedOptions" title="Advanced options">
+            <param name="nops" type="boolean" truevalue="" falsevalue="--noPS" checked="true" label="Do not produce postscript drawing of the mfe structure (reduces run-time)" help="(--noPS)"/>
             <param name="nolp" type="boolean" truevalue="" falsevalue="--noLP" checked="true" label="Allow lonely base-pairs" help="(--noLP)"/>
             <param name="nogu" type="boolean" truevalue="" falsevalue="--noGU" checked="true" label="Allow GU pairing" help="--noGU"/>
             <param name="noclosinggu" type="boolean" truevalue="" falsevalue="--noClosingGU" checked="true" label="Allow GU pairing at the ends" help="Allow pairing of G and U at the ends of helices. --noClosingGU"/>


### PR DESCRIPTION
the ps secondary structure drawing of the structures is not always needed. Skip option avoids large overhead of ps files generation and handling.