### PR TITLE
Update methyl dackel

### DIFF
--- a/tools/methyldackel/MethylDackel.xml
+++ b/tools/methyldackel/MethylDackel.xml
@@ -1,7 +1,7 @@
-<tool id="pileometh" name="MethylDackel" version="0.2.1">
+<tool id="pileometh" name="MethylDackel" version="0.3.0">
     <description>A tool for processing bisulfite sequencing alignments</description>
     <requirements>
-        <requirement type="package" version="0.2.1">methyldackel</requirement>
+        <requirement type="package" version="0.3.0">methyldackel</requirement>
     </requirements>
     <stdio>
         <!-- Anything other than zero is an error -->
@@ -22,6 +22,7 @@
         MethylDackel
             $main_task.task
 
+            -@ "${GALAXY_SLOTS:-4}"
             #if $main_task.task == "extract":
                 -o output
                 $main_task.mergeContext

--- a/tools/methyldackel/MethylDackel.xml
+++ b/tools/methyldackel/MethylDackel.xml
@@ -22,7 +22,7 @@
         MethylDackel
             $main_task.task
 
-            -@ "${GALAXY_SLOTS:-4}"
+            -@ \${GALAXY_SLOTS:-4}
             #if $main_task.task == "extract":
                 -o output
                 $main_task.mergeContext
@@ -52,7 +52,7 @@
                 -D $advanced_options.max_pbdepth
                 #if $main_task.task == "extract":
                     --minOppositeDepth $advanced_options.minOppositeDepth
-                    --maxVarianteFrac $advanced_options.maxVariantFrac
+                    --maxVariantFrac $advanced_options.maxVariantFrac
                     -d $advanced_options.min_pbdepth
                     --ignoreFlags $advanced_options.ignoreFlags
                     --requireFlags $advanced_options.requireFlags
@@ -316,7 +316,7 @@
             <param name="reference_source_selector" value="history" />
             <param name="ref_file" value="cg100.fa" ftype="fasta" />
             <param name="input_sortedAlignBAM" value="cg_aln.bam" ftype="bam"/>
-            <output name="outFileMbiasCpG" file="test_2_output.svg" ftype="svg" compare="diff"/>
+            <output name="outFileMbiasCpGOT" file="test_2_output.svg" ftype="svg" compare="diff"/>
         </test>
         <test>
             <param name="task" value="extract" />

--- a/tools/methyldackel/MethylDackel.xml
+++ b/tools/methyldackel/MethylDackel.xml
@@ -51,6 +51,8 @@
                 -p $advanced_options.min_phred
                 -D $advanced_options.max_pbdepth
                 #if $main_task.task == "extract":
+                    --minOppositeDepth $advanced_options.minOppositeDepth
+                    --maxVarianteFrac $advanced_options.maxVariantFrac
                     -d $advanced_options.min_pbdepth
                     --ignoreFlags $advanced_options.ignoreFlags
                     --requireFlags $advanced_options.requireFlags
@@ -154,6 +156,10 @@
                     help="By deault, any alignment marked as secondary (bit 0x100), failing QC (bit 0x200), a PCR/optical duplicate (0x400) or supplemental (0x800) is ignored. This equates to a value of 0xF00 or 3840 in decimal. If you would like to change that, you can specify a new value here." />
                 <param name="requireFlags" type="integer" value="0" label="Require alignment flags"
                     help="Require each alignment to have all bits in this value present, or else the alignment is ignored. This is equivalent to the -f option in samtools. The default is 0, which includes all alignments." />
+                <param name="minOppositeDepth" type="integer" value="0" min="0" label="Minimum depth for variant avoidance"
+                    help="The minimum depth on the strand opposite of a C required to flag the position as possibly being a SNP. The default is 0 (ignore possible SNPs). Setting this to a value above 0 will cause the position to be ignored if a given fraction of non-G bases are present on the opposite strand and the overall coverage there is at least what is specified here." />
+                <param name="maxVariantFrac" type="float" value="1.0" min="0.0" max="1.0" label="Maximum tolerated variant fraction"
+                    help="If the depth on the strand opposite of a C is at least that specified by 'Minimum depth for variant avoidance', and the fraction of non-G bases exceeds this value, then methylation extraction is skipped for this position." />
 
                 <param name="fraction" type="boolean" checked="false" truevalue="--fraction" falsevalue=""
                     label="Extract fractional methylation (only) at each position. This is mutually exclusive with --counts, --logit, and --methylKit" />

--- a/tools/methyldackel/MethylDackel.xml
+++ b/tools/methyldackel/MethylDackel.xml
@@ -448,6 +448,12 @@ Note that these options may be combined with `--mergeContext`. However, `MethylD
 
 methylKit has its own format, which can be produced with the `--methylKit` option. Merging Cs into CpGs or CHGs is forbidden in this format. Likewise, this option is mutually exclusive with `--logit` et al.
 
+**Excluding likely variant sites**
+
+If your samples are not genetically homogenous, it can sometimes be advantageous to exclude likely variant sites from methylation extraction. As an example, since unmethylated Cs are read as Ts, extracting methylation from a position with a C->T mutation will cause incorrect results. In such a case, the opposite strand will have an A rather than a G (in the non-variant case, there would be a G regardless of methylation status). MethylDackel tracks the number of non-Gs on the strand opposite of Cs in the reference sequence. If the fraction of these exceeds the `--maxVariantFrac` option, then that position will be excluded from output. To exclude cases where the `--maxVariantFrac` value is exceeded only due to low coverage, the opposite strand must have a depth of coverage of at least `--minOppositeDepth`. Note that the default value for `--minOppositeDepth` is 0, indicating that the variant site exclusion process is skipped.
+
+Note that if one additionally specifies `--mergeContext`, that a given CpG or CHG will be excluded from output if either of its individual Cs would be excluded given the specified `--minOppositeDepth` and `--maxVariantFrac`.
+
 
 -----
 

--- a/tools/methyldackel/test-data/test_2.bedGraph
+++ b/tools/methyldackel/test-data/test_2.bedGraph
@@ -1,1 +1,2 @@
 track type="bedGraph" description="output CHH methylation levels"
+chrCG	98	99	100	1	0

--- a/tools/methyldackel/tool_dependencies.xml
+++ b/tools/methyldackel/tool_dependencies.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <tool_dependency>
-    <package name="methyldackel" version="0.2.1">
+    <package name="methyldackel" version="0.3.0">
         <install version="1.0">
             <actions>
-                <action target_filename="MethylDackel-0.2.1.tar.gz" type="download_by_url">https://github.com/dpryan79/MethylDackel/archive/0.2.1.tar.gz</action>
+                <action target_filename="MethylDackel-0.3.0.tar.gz" type="download_by_url">https://github.com/dpryan79/MethylDackel/archive/0.3.0.tar.gz</action>
                 <action type="shell_command">make</action>
                 <action type="shell_command">mkdir $INSTALL_DIR/bin</action>
                 <action type="shell_command">make install prefix=$INSTALL_DIR/bin/</action>


### PR DESCRIPTION
This is version 0.3.0, which supports multiple threads and detecting/avoiding likely SNPs. This also fixes a bug with methylation extraction from the last 1-3 bases in a contig.