### PR TITLE
(Another) Fix for the SortMeRNA data manager

### DIFF
--- a/data_managers/data_manager_sortmerna_database_downloader/data_manager/data_manager_sortmerna_download.py
+++ b/data_managers/data_manager_sortmerna_database_downloader/data_manager/data_manager_sortmerna_download.py
@@ -126,23 +126,28 @@ def move_index_files(archive_content_path, target_dir, data_tables, version):
         if not filename.endswith("fasta"):
             continue
         input_filepath = os.path.join(file_dir, filename)
-        output_filepath = os.path.join(target_dir, filename)
-        # Move file
-        os.rename(input_filepath, output_filepath)
+        # Extract the db name
+        db_name = os.path.splitext(filename)[0]
+        # Create the directory where to put the fasta files and indexed files
+        filedir = os.path.join(target_dir, db_name)
+        os.mkdir(filedir)
+        fasta_filepath = os.path.join(filedir, "%s.fasta" % db_name)
+        indexed_filepath = os.path.join(filedir, db_name)
+        # Move the fasta file
+        os.rename(input_filepath, fasta_filepath)
         # Index the file with indexdb_rna
         command = "indexdb_rna --ref %s,%s" % (
-            output_filepath,
-            os.path.splitext(output_filepath)[0])
+            fasta_filepath,
+            indexed_filepath)
         process = subprocess.call(command, shell=True )
         # Add entry in the data table
-        db_name = os.path.splitext(filename)[0]
         add_data_table_entry(
             data_tables,
             "rRNA_databases",
             dict(
                 value="%s-%s" %(version, db_name),
                 name=db_name,
-                path=output_filepath))
+                path=filedir))
 
 
 def download_db(data_tables, version, target_dir):

--- a/data_managers/data_manager_sortmerna_database_downloader/data_manager/data_manager_sortmerna_download.py
+++ b/data_managers/data_manager_sortmerna_database_downloader/data_manager/data_manager_sortmerna_download.py
@@ -140,7 +140,7 @@ def move_index_files(archive_content_path, target_dir, data_tables, version):
             data_tables,
             "rRNA_databases",
             dict(
-                value=version,
+                value="%s-%s" %(version, db_name),
                 name=db_name,
                 path=output_filepath))
 

--- a/data_managers/data_manager_sortmerna_database_downloader/data_manager/data_manager_sortmerna_download.py
+++ b/data_managers/data_manager_sortmerna_database_downloader/data_manager/data_manager_sortmerna_download.py
@@ -4,6 +4,7 @@
 import argparse
 import json
 import os
+import shutil
 import tarfile
 import requests
 import subprocess
@@ -134,7 +135,7 @@ def move_index_files(archive_content_path, target_dir, data_tables, version):
         fasta_filepath = os.path.join(filedir, "%s.fasta" % db_name)
         indexed_filepath = os.path.join(filedir, db_name)
         # Move the fasta file
-        os.rename(input_filepath, fasta_filepath)
+        shutil.move(input_filepath, fasta_filepath)
         # Index the file with indexdb_rna
         command = "indexdb_rna --ref %s,%s" % (
             fasta_filepath,

--- a/data_managers/data_manager_sortmerna_database_downloader/data_manager/data_manager_sortmerna_download.xml
+++ b/data_managers/data_manager_sortmerna_database_downloader/data_manager/data_manager_sortmerna_download.xml
@@ -1,4 +1,4 @@
-<tool id="data_manager_sortmerna_download" name="Download SortMeRNA" version="@VERSION@.1" tool_type="manage_data">
+<tool id="data_manager_sortmerna_download" name="Download SortMeRNA" version="@VERSION@.2" tool_type="manage_data">
     <description>reference databases</description>
     <macros>
         <import>macros.xml</import>

--- a/data_managers/data_manager_sortmerna_database_downloader/data_manager/data_manager_sortmerna_download.xml
+++ b/data_managers/data_manager_sortmerna_database_downloader/data_manager/data_manager_sortmerna_download.xml
@@ -1,4 +1,4 @@
-<tool id="data_manager_sortmerna_download" name="Download SortMeRNA" version="@VERSION@.2" tool_type="manage_data">
+<tool id="data_manager_sortmerna_download" name="Download SortMeRNA" version="@VERSION@.1" tool_type="manage_data">
     <description>reference databases</description>
     <macros>
         <import>macros.xml</import>

--- a/data_managers/data_manager_sortmerna_database_downloader/data_manager_conf.xml
+++ b/data_managers/data_manager_sortmerna_database_downloader/data_manager_conf.xml
@@ -6,11 +6,11 @@
                 <column name="value" />  <!-- columns that are going to be specified by the Data Manager Tool -->
                 <column name="name" />  <!-- columns that are going to be specified by the Data Manager Tool -->
                 <column name="path" output_ref="out_file" >
-                    <move type="file">
+                    <move type="directory">
                         <source>${path}</source>
                         <target base="${GALAXY_DATA_MANAGER_DATA_PATH}">rRNA_databases/${name}</target>
                     </move>
-                    <value_translation>${GALAXY_DATA_MANAGER_DATA_PATH}/rRNA_databases/${name}</value_translation>
+                    <value_translation>${GALAXY_DATA_MANAGER_DATA_PATH}/rRNA_databases/${name}/${name}.fasta</value_translation>
                     <value_translation type="function">abspath</value_translation>
                 </column>
             </output>

--- a/tools/rna_tools/sortmerna/sortmerna.xml
+++ b/tools/rna_tools/sortmerna/sortmerna.xml
@@ -35,17 +35,13 @@ sortmerna --version 2>&1|grep 'SortMeRNA version'
             #set $sep = ':'
         #end for
     #else if str( $databases_type.databases_selector ) == 'cached_to_index'
-        ## databases path is not directly accessible, must match by hand with LOC file contents
-        #set $data_table = dict([(_[0], _[2]) for _ in $databases_type.input_databases.input.options.tool_data_table.data])
-        #for $db in $databases_type.input_databases.value
-            #set $ref += $sep + $data_table[$db] + '.fasta,' + $data_table[$db] + '-reindexed'
+        #for $db in $databases_type.input_databases.fields.path.split(",")
+            #set $ref += $sep + $db + ',' + $os.path.splitext($db)[0] + '-reindexed'
             #set $sep = ':'
         #end for
-    #else:
-        ## databases path is not directly accessible, must match by hand with LOC file contents
-        #set $data_table = dict([(_[0], _[2]) for _ in $databases_type.input_databases.input.options.tool_data_table.data])
-        #for $db in $databases_type.input_databases.value
-            #set $ref += $sep + $data_table[$db] + '.fasta,' + $data_table[$db]
+    #else
+        #for $db in $databases_type.input_databases.fields.path.split(",")
+            #set $ref += $sep + $db + ',' + $os.path.splitext($db)[0]
             #set $sep = ':'
         #end for
     #end if


### PR DESCRIPTION
Hi,

I had some issues with SortMeRNA because of:

- Duplication of the values in the tool data table
- Incomplete copy of the indexed files

I also simplified the extraction of the path to the cached data in the SortMeRNA wrapper.

I ran some tests locally (using the data manager on the TTS). It worked...

Bérénice