### PR TITLE
Minor cleanup of help text for tac.

### DIFF
--- a/tools/text_processing/text_processing/tac.xml
+++ b/tools/text_processing/text_processing/tac.xml
@@ -70,19 +70,20 @@ Mandatory arguments to long options are mandatory for short options too:
 
 Input file:
 
- 0 1 2 3 4 5 # 6 7 8 9
+    0 1 2 3 4 5 # 6 7 8 9
 
 
 default settings:
 
- 9 8 7 6 # 5 4 3 2 1 0
+    9 8 7 6 # 5 4 3 2 1 0
 
 with option -s 5:
- # 6 7 8 9 0 1 2 3 4 5
+
+    # 6 7 8 9 0 1 2 3 4 5
 
 with option -b and -s 5:
 
- 5 # 6 7 8 9 0 1 2 3 4
+    5 # 6 7 8 9 0 1 2 3 4
 
 @REFERENCES@
 ]]>


### PR DESCRIPTION
The help for `-s 5` was visually different from the other examples.