### PR TITLE
Enable stdout SAM file to be written as history item

### DIFF
--- a/tools/salmon/salmon.xml
+++ b/tools/salmon/salmon.xml
@@ -339,7 +339,7 @@
             <filter>geneMap</filter>
         </data>
         <data name="output_sam" format="sam" label="${tool.name} on ${on_string} (SAM format)">
-            <filter>str(adv.writeMappings)</filter> <!-- This filter condition seems to always evaluate to True, even when writeMappings is False. Needs to be changed (I'm not sure what to) so that a SAM file isn't produced as output if writeMappings is set to 'No'/False. -->
+            <filter>adv['writeMappings']</filter>
         </data>
     </outputs>
 

--- a/tools/salmon/salmon.xml
+++ b/tools/salmon/salmon.xml
@@ -132,7 +132,6 @@
             #if $adv.forgettingFactor:
                 --forgettingFactor $adv.forgettingFactor
             #end if
-            $adv.writeMappings
             #if str($adv.maxOcc):
                 --maxOcc $adv.maxOcc
             #end if
@@ -167,6 +166,9 @@
                 --vbPrior $adv.vbPrior
             #end if
             $adv.writeUnmappedNames
+            #if str($adv.writeMappings):
+                $adv.writeMappings > ${output_sam}
+            #end if
 ]]>
     </command>
 
@@ -239,7 +241,7 @@
         <section name="adv" title="Additional Options">
             <param argument="--writeMappings" type="boolean" truevalue="--writeMappings" falsevalue="" checked="False"
                 label="Write Mappings"
-                help=" Setting this option then the quasi-mapping results will be written out in SAM-cpmpatible format. By default, output will be directed to stdout, but an alternative file name can be provided instead." />
+                help="If this option is set to 'Yes', then the quasi-mapping results will be written out in SAM-compatible format. By default, output is directed to stdout." />
             <param argument="--incompatPrior" type="float" optional="True" value="9.9999999999999995e-21"
                 label="Incompatible Prior"
                 help="This option sets the prior probability that an alignment that disagrees with the specified library type (--libType) results from the true fragment origin. Setting this to 0 specifies that alignments that disagree with the library type should be 'impossible', while setting it to 1 says that alignments that disagree with the library type are no less likely than those that do" />
@@ -335,6 +337,9 @@
         <data name="output_quant" format="tabular" from_work_dir="output/quant.sf" label="${tool.name} on ${on_string} (Quantification)" />
         <data name="output_gene_quant" format="tabular" from_work_dir="output/quant.genes.sf" label="${tool.name} on ${on_string} (Gene Quantification)">
             <filter>geneMap</filter>
+        </data>
+        <data name="output_sam" format="sam" label="${tool.name} on ${on_string} (SAM format)">
+            <filter>str(adv.writeMappings)</filter> <!-- This filter condition seems to always evaluate to True, even when writeMappings is False. Needs to be changed (I'm not sure what to) so that a SAM file isn't produced as output if writeMappings is set to 'No'/False. -->
         </data>
     </outputs>
 


### PR DESCRIPTION
Updated <outputs> and <command> sections. When --writeMappings is set to Yes/True, a SAM-formatted file is written to stdout and redirected to its own history item (name=output_sam).

NOTE: This filter condition (line 342) seems to always evaluate to True, even when writeMappings is False. Needs to be changed (I'm not sure what to) so that a SAM file isn't produced as output if writeMappings is set to 'No'/False. Any ideas, @bgruening ?