### PR TITLE
Reduce genomics/proteomics clashes. Change sensitivity flags to select menu. 

### DIFF
--- a/tools/diamond/diamond.xml
+++ b/tools/diamond/diamond.xml
@@ -38,8 +38,12 @@
         #end if
 
         --compress '0'
-        $sensitive
-        $more_sensitive
+        #if $sensitivity == "1"
+          --sensitive
+        #else if $sensitivity == "2"
+          --more-sensitive
+        #end if
+
         --gapopen '$gapopen'
         --gapextend '$gapextend'
         --matrix '$matrix'
@@ -150,8 +154,11 @@
                 <param argument="--salltitles" type="boolean" truevalue="--salltitles" falsevalue="" checked="true" label="Include full length subject titles in output?" help=""/>
             </when>
         </conditional>
-        <param argument="--sensitive" type="boolean" truevalue="--sensitive" falsevalue="" checked="false" label="Trigger the sensitive alignment mode with a 16x9 seed shape configuration?" help=""/>
-        <param name="more_sensitive" argument="--more-sensitive" type="boolean" truevalue="--more-sensitive" falsevalue="" checked="false" label="Trigger the more sensitive mode?" help="This mode provides some additional sensitivity compared to the sensitive mode."/>
+        <param name='sensitivity' type="select" label="Sensitivity Mode" help="Choose one of the sensitivity modes. More sensitivity may increase computation time">
+          <option value="0" selected="True">Default</option>
+          <option value="1">Sensitive</option>
+          <option value="2">More Sensitive</option>
+        </param>
         <param argument="--gapopen" type="integer" value="11" label="Gap open penalty" help="" />
         <param argument="--gapextend" type="integer" value="1" label="Gap extension penalty" help="" />
         <param argument="--matrix" type="select" label="Scoring matrix" help="In brackets are the supported values for (gap open)/(gap extend)">
@@ -215,8 +222,7 @@
             <param name="query_gencode" value="1"/>
             <param name="outfmt" value="6"/>
             <param name="fields" value="qseqid,sseqid,pident,length,mismatch,gapopen,qstart,qend,sstart,send,evalue,bitscore"/>
-            <param name="sensitive" value=""/>
-            <param name="more_sensitive" value=""/>
+            <param name="sensitivity" value="0"/>
             <param name="gapopen" value="11"/>
             <param name="gapextend" value="1"/>
             <param name="matrix" value="BLOSUM62"/>
@@ -242,7 +248,7 @@ On Illumina reads of length 100-150bp, in fast mode, DIAMOND is about 20,000 tim
 about 80-90% of all matches that BLASTX finds, with an e-value of at most 1e-5. In sensitive mode, DIAMOND ist about 2,500
 times faster than BLASTX, finding more than 94% of all matches.
 
-The DIAMOND algorithm is designed for the alignment of large datasets. The algorithm is not efficient for a small number of query sequences or only a single one of them, and speed will be low. BLAST is recommend for small datasets.
+The DIAMOND algorithm is designed for the alignment of large datasets. The algorithm is not efficient for a small number of query sequences or only a single one of them, and speed will be low. BLAST is recommended for small datasets.
 
 .. _DIAMOND: http://ab.inf.uni-tuebingen.de/software/diamond/
 

--- a/tools/diamond/diamond.xml
+++ b/tools/diamond/diamond.xml
@@ -1,4 +1,4 @@
-<tool id="bg_diamond" name="Diamond" version="@VERSION@">
+<tool id="bg_diamond" name="Diamond" version="@VERSION@.1">
     <description>alignment tool for short sequences against a protein database</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/diamond/diamond.xml
+++ b/tools/diamond/diamond.xml
@@ -18,11 +18,13 @@
     &&
 
     diamond
-        $method_select
+        $method_select.method_select
         --threads "\${GALAXY_SLOTS:-12}"
         --db ./database
         --query '$query'
-        --query-gencode '$query_gencode'
+        #if $method_select.method_select == "blastx"
+          --query-gencode '$query_gencode'
+        #end if
 
         #if $output.outfmt == "5"
             --outfmt '5'
@@ -68,18 +70,45 @@
     </command>
 
     <inputs>
-        <param name="method_select" type="select" label="What do you want to align?" help="(--blastp/--blastx)">
-            <option value="blastp">Align amino acid query sequences (blastp)</option>
-            <option value="blastx">Align DNA query sequences (blastx)</option>
-        </param>
+        <conditional name="method_select">
+          <param name="method_select" type="select" label="What do you want to align?" help="(--blastp/--blastx)">
+              <option value="blastp">Align amino acid query sequences (blastp)</option>
+              <option value="blastx">Align DNA query sequences (blastx)</option>
+          </param>
+          <when value="blastx">
+            <param name="query_gencode" argument="--query-gencode" type="select" label="Genetic code used for translation of query in BLASTX mode" help="">
+                <option value="1">The Standard Code</option>
+                <option value="2">The Vertebrate Mitochondrial Code</option>
+                <option value="3">The Yeast Mitochondrial Code</option>
+                <option value="4">The Mold, Protozoan, and Coelenterate Mitochondrial Code and the Mycoplasma/Spiroplasma Code</option>
+                <option value="5">The Invertebrate Mitochondrial Code</option>
+                <option value="6">The Ciliate, Dasycladacean and Hexamita Nuclear Code</option>
+                <option value="9">The Echinoderm and Flatworm Mitochondrial Code</option>
+                <option value="10">The Euplotid Nuclear Code</option>
+                <option value="11">The Bacterial, Archaeal and Plant Plastid Code</option>
+                <option value="12">The Alternative Yeast Nuclear Code</option>
+                <option value="13">The Ascidian Mitochondrial Code</option>
+                <option value="14">The Alternative Flatworm Mitochondrial Code</option>
+                <option value="16">Chlorophycean Mitochondrial Code</option>
+                <option value="21">Trematode Mitochondrial Code</option>
+                <option value="22">Scenedesmus obliquus Mitochondrial Code</option>
+                <option value="23">Thraustochytrium Mitochondrial Code</option>
+                <option value="24">Pterobranchia Mitochondrial Code</option>
+                <option value="5">Candidate Division SR1 and Gracilibacteria Code</option>
+                <option value="26">Pachysolen tannophilus Nuclear Code</option>
+            </param>
+          </when>
+          <when value="blastp">
+          </when>
+        </conditional>
         <param argument="--query" type="data" format="fasta,fastq" label="Input query file in FASTA or FASTQ format" />
         <conditional name="ref_db_source">
-          <param name="db_source" type="select" label="Will you select a reference genome from your history or use a built-in index?" help="Built-ins were indexed using default options">
+          <param name="db_source" type="select" label="Will you select a reference database from your history or use a built-in index?" help="Built-ins were indexed using default options">
             <option value="indexed">Use a built-in index</option>
             <option value="history">Use one from the history</option>
           </param>
           <when value="indexed">
-            <param name="index" type="select" label="Select a reference genome" help="If your genome of interest is not listed, contact your Galaxy admin">
+            <param name="index" type="select" label="Select a reference database" help="If your database of interest is not listed, contact your Galaxy admin">
               <options from_data_table="diamond_database">
                 <filter type="sort_by" column="2"/>
                 <validator type="no_options" message="No indexes are available for the selected input dataset"/>
@@ -90,27 +119,6 @@
             <param name="reference_database" type="data" format="dmnd" label="Select the reference database" />
           </when>
         </conditional>
-        <param name="query_gencode" argument="--query-gencode" type="select" label="Genetic code used for translation of query in BLASTX mode" help="">
-            <option value="1">The Standard Code</option>
-            <option value="2">The Vertebrate Mitochondrial Code</option>
-            <option value="3">The Yeast Mitochondrial Code</option>
-            <option value="4">The Mold, Protozoan, and Coelenterate Mitochondrial Code and the Mycoplasma/Spiroplasma Code</option>
-            <option value="5">The Invertebrate Mitochondrial Code</option>
-            <option value="6">The Ciliate, Dasycladacean and Hexamita Nuclear Code</option>
-            <option value="9">The Echinoderm and Flatworm Mitochondrial Code</option>
-            <option value="10">The Euplotid Nuclear Code</option>
-            <option value="11">The Bacterial, Archaeal and Plant Plastid Code</option>
-            <option value="12">The Alternative Yeast Nuclear Code</option>
-            <option value="13">The Ascidian Mitochondrial Code</option>
-            <option value="14">The Alternative Flatworm Mitochondrial Code</option>
-            <option value="16">Chlorophycean Mitochondrial Code</option>
-            <option value="21">Trematode Mitochondrial Code</option>
-            <option value="22">Scenedesmus obliquus Mitochondrial Code</option>
-            <option value="23">Thraustochytrium Mitochondrial Code</option>
-            <option value="24">Pterobranchia Mitochondrial Code</option>
-            <option value="5">Candidate Division SR1 and Gracilibacteria Code</option>
-            <option value="26">Pachysolen tannophilus Nuclear Code</option>
-        </param>
         <conditional name="output">
             <param argument="--outfmt" type="select" label="Format of output file " help="">
                 <option value="5">BLAST XML</option>
@@ -219,7 +227,6 @@
             <param name="query" value="protein.fasta" ftype="fasta"/>
             <param name="db_source" value="history"/>
             <param name="reference_database" value="db.dmnd"/>
-            <param name="query_gencode" value="1"/>
             <param name="outfmt" value="6"/>
             <param name="fields" value="qseqid,sseqid,pident,length,mismatch,gapopen,qstart,qend,sstart,send,evalue,bitscore"/>
             <param name="sensitivity" value="0"/>


### PR DESCRIPTION
The phrase 'reference genome' was confusing when using Diamond for proteomics. Also, the choice of query translation is not relevant for proteins. 

Finally, I changed the two sensitivity flag options to a select menu, to avoid possible option clash if someone is confused about how the options 'stack' (like I was) - see <https://github.com/bbuchfink/diamond/issues/160>. 