### PR TITLE
Link DOIs to preferred resolver

### DIFF
--- a/tools/iprscan/interproscan.xml
+++ b/tools/iprscan/interproscan.xml
@@ -220,17 +220,17 @@ References
 Zdobnov EM, Apweiler R (2001)
 InterProScan an integration platform for the signature-recognition methods in InterPro.
 Bioinformatics 17, 847-848.
-http://dx.doi.org/10.1093/bioinformatics/17.9.847
+https://doi.org/10.1093/bioinformatics/17.9.847
 
 Quevillon E, Silventoinen V, Pillai S, Harte N, Mulder N, Apweiler R, Lopez R (2005)
 InterProScan: protein domains identifier.
 Nucleic Acids Research 33 (Web Server issue), W116-W120.
-http://dx.doi.org/10.1093/nar/gki442
+https://doi.org/10.1093/nar/gki442
 
 Hunter S, Apweiler R, Attwood TK, Bairoch A, Bateman A, Binns D, Bork P, Das U, Daugherty L, Duquenne L, Finn RD, Gough J, Haft D, Hulo N, Kahn D, Kelly E, Laugraud A, Letunic I, Lonsdale D, Lopez R, Madera M, Maslen J, McAnulla C, McDowall J, Mistry J, Mitchell A, Mulder N, Natale D, Orengo C, Quinn AF, Selengut JD, Sigrist CJ, Thimma M, Thomas PD, Valentin F, Wilson D, Wu CH, Yeats C. (2009)
 InterPro: the integrative protein signature database.
 Nucleic Acids Research 37 (Database Issue), D224-228.
-http://dx.doi.org/10.1093/nar/gkn785
+https://doi.org/10.1093/nar/gkn785
 
 
 This wrapper is available to install into other Galaxy Instances via the Galaxy Tool Shed at

--- a/tools/iprscan5/readme.rst
+++ b/tools/iprscan5/readme.rst
@@ -37,7 +37,7 @@ publication, in addition to citing the invididual underlying tools, please cite:
 Peter Cock, Bjoern Gruening, Konrad Paszkiewicz and Leighton Pritchard (2013).
 Galaxy tools and workflows for sequence analysis with applications
 in molecular plant pathology. PeerJ 1:e167
-http://dx.doi.org/10.7717/peerj.167
+https://doi.org/10.7717/peerj.167
 
 Full reference information is included in the help text.
 

--- a/tools/sklearn/main_macros.xml
+++ b/tools/sklearn/main_macros.xml
@@ -764,7 +764,7 @@ def columns(f,c):
               month        = feb,
               year         = 2015,
               doi          = {10.5281/zenodo.15094},
-              url          = {http://dx.doi.org/10.5281/zenodo.15094}
+              url          = {https://doi.org/10.5281/zenodo.15094}
                     }
                         }
         </citation>

--- a/tools/sklearn/main_macros.xml
+++ b/tools/sklearn/main_macros.xml
@@ -755,19 +755,7 @@ def columns(f,c):
   <!--Citations-->
   <xml name="eden_citation">
     <citations>
-        <citation type="bibtex">
-            @misc{fabrizio_costa_2015_15094,
-              author       = {Fabrizio Costa and
-                              Björn Grüning and
-                              gigolo},
-              title        = {EDeN: EDeN - Graph Vectorizer},
-              month        = feb,
-              year         = 2015,
-              doi          = {10.5281/zenodo.15094},
-              url          = {https://doi.org/10.5281/zenodo.15094}
-                    }
-                        }
-        </citation>
+        <citation type="doi">10.5281/zenodo.15094</citation>
     </citations>
   </xml>
 

--- a/tools/staging_area/blast_unique_best_bit_score.xml
+++ b/tools/staging_area/blast_unique_best_bit_score.xml
@@ -47,7 +47,7 @@ Galaxy. See also:
 Punta and Ofran (2008) The Rough Guide to In Silico Function Prediction,
 or How To Use Sequence and Structure Information To Predict Protein
 Function. PLoS Comput Biol 4(10): e1000160.
-http://dx.doi.org/10.1371/journal.pcbi.1000160
+https://doi.org/10.1371/journal.pcbi.1000160
 
 
 **Suggested settings**

--- a/workflows/glimmer3/readme.rst
+++ b/workflows/glimmer3/readme.rst
@@ -68,14 +68,14 @@ For Glimmer3 please cite:
 Delcher, A.L., Bratke, K.A., Powers, E.C., and Salzberg, S.L. (2007)
 Identifying bacterial genes and endosymbiont DNA with Glimmer.
 Bioinformatics 23(6), 673-679.
-http://dx.doi.org/10.1093/bioinformatics/btm009
+https://doi.org/10.1093/bioinformatics/btm009
 
 For EMBOSS please cite:
 
 Rice, P., Longden, I. and Bleasby, A. (2000)
 EMBOSS: The European Molecular Biology Open Software Suite
 Trends in Genetics 16(6), 276-277.
-http://dx.doi.org/10.1016/S0168-9525(00)02024-2
+https://doi.org/10.1016/S0168-9525(00)02024-2
 
 
 Additional References
@@ -84,7 +84,7 @@ Additional References
 Rohde, H., Qin, J., Cui, Y., Li, D., Loman, N.J., et al. (2011)
 Open-source genomic analysis of shiga-toxin-producing E. coli O104:H4.
 New England Journal of Medicine 365, 718-724.
-http://dx.doi.org/10.1056/NEJMoa1107643
+https://doi.org/10.1056/NEJMoa1107643
 
 
 Availability

--- a/workflows/ncbi_blast_plus/find_genes_located_nearby/readme.rst
+++ b/workflows/ncbi_blast_plus/find_genes_located_nearby/readme.rst
@@ -60,7 +60,7 @@ Peter J. A. Cock, John M. Chilton, Björn Grüning, James E. Johnson, Nicola Sor
 NCBI BLAST+ integrated into Galaxy
 
 * http://biorxiv.org/content/early/2015/01/21/014043
-* http://dx.doi.org/10.1101/014043
+* https://doi.org/10.1101/014043
 
 
 Availability

--- a/workflows/ncbi_blast_plus/find_three_genes_located_nearby/readme.rst
+++ b/workflows/ncbi_blast_plus/find_three_genes_located_nearby/readme.rst
@@ -101,7 +101,7 @@ Peter J. A. Cock, John M. Chilton, Björn Grüning, James E. Johnson, Nicola Sor
 NCBI BLAST+ integrated into Galaxy
 
 * http://biorxiv.org/content/early/2015/01/21/014043
-* http://dx.doi.org/10.1101/014043
+* https://doi.org/10.1101/014043
 
 
 Availability


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates some static DOI links that still point to the old resolver.

Cheers!