### PR TITLE
add header option for tabular data input

### DIFF
--- a/tools/sklearn/ensemble.xml
+++ b/tools/sklearn/ensemble.xml
@@ -22,10 +22,10 @@ import pandas
 import pickle
 from scipy.io import mmread
 
+@COLUMNS_FUNCTION@
+
 input_json_path = sys.argv[1]
 params = json.load(open(input_json_path, "r"))
-
-@COLUMNS_FUNCTION@
 
 #if $selected_tasks.selected_task == "train":
 
@@ -33,21 +33,23 @@ algorithm = params["selected_tasks"]["selected_algorithms"]["selected_algorithm"
 options = params["selected_tasks"]["selected_algorithms"]["options"]
 input_type = params["selected_tasks"]["selected_algorithms"]["input_options"]["selected_input"]
 if input_type=="tabular":
+    header = 'infer' if params["selected_tasks"]["selected_algorithms"]["input_options"]["header1"] else None
     X = read_columns(
             "$selected_tasks.selected_algorithms.input_options.infile1",
             "$selected_tasks.selected_algorithms.input_options.col1",
             sep='\t',
-            header=None,
+            header=header,
             parse_dates=True
     )
 else:
     X = mmread(open("$selected_tasks.selected_algorithms.input_options.infile1", 'r'))
 
+header = 'infer' if params["selected_tasks"]["selected_algorithms"]["input_options"]["header2"] else None
 y = read_columns(
         "$selected_tasks.selected_algorithms.input_options.infile2",
         "$selected_tasks.selected_algorithms.input_options.col2",
         sep='\t',
-        header=None,
+        header=header,
         parse_dates=True
 )
 

--- a/tools/sklearn/generalized_linear.xml
+++ b/tools/sklearn/generalized_linear.xml
@@ -33,22 +33,24 @@ algorithm = params["selected_tasks"]["selected_algorithms"]["selected_algorithm"
 options = params["selected_tasks"]["selected_algorithms"]["options"]
 
 #if $selected_tasks.selected_algorithms.input_options.selected_input=="tabular":
+header = 'infer' if params["selected_tasks"]["selected_algorithms"]["input_options"]["header1"] else None
 X = read_columns(
         "$selected_tasks.selected_algorithms.input_options.infile1",
         "$selected_tasks.selected_algorithms.input_options.col1",
         sep='\t',
-        header=None,
+        header=header,
         parse_dates=True
 )
 #else:
 X = mmread(open("$selected_tasks.selected_algorithms.input_options.infile1", 'r'))
 #end if
 
+header = 'infer' if params["selected_tasks"]["selected_algorithms"]["input_options"]["header2"] else None
 y = read_columns(
         "$selected_tasks.selected_algorithms.input_options.infile2",
         "$selected_tasks.selected_algorithms.input_options.col2",
         sep='\t',
-        header=None,
+        header=header,
         parse_dates=True
 )
 

--- a/tools/sklearn/main_macros.xml
+++ b/tools/sklearn/main_macros.xml
@@ -336,8 +336,10 @@ def read_columns(f, c, **args):
 
   <xml name="samples_tabular" token_multiple1="False" token_multiple2="False">
     <param name="infile1" type="data" format="tabular" label="Training samples dataset:"/>
+    <param name="header1" type="boolean" optional="True" truevalue="booltrue" falsevalue="boolfalse" checked="True" label="Does the dataset contain header:" />
     <param name="col1" multiple="@MULTIPLE1@" type="data_column" data_ref="infile1" label="Select target column(s):"/>
     <param name="infile2" type="data" format="tabular" label="Dataset containing class labels:"/>
+    <param name="header2" type="boolean" optional="True" truevalue="booltrue" falsevalue="boolfalse" checked="True" label="Does the dataset contain header:" />
     <param name="col2" multiple="@MULTIPLE2@" type="data_column" data_ref="infile2" label="Select target column(s):"/>
     <yield/>
   </xml>

--- a/tools/sklearn/main_macros.xml
+++ b/tools/sklearn/main_macros.xml
@@ -336,10 +336,10 @@ def read_columns(f, c, **args):
 
   <xml name="samples_tabular" token_multiple1="False" token_multiple2="False">
     <param name="infile1" type="data" format="tabular" label="Training samples dataset:"/>
-    <param name="header1" type="boolean" optional="True" truevalue="booltrue" falsevalue="boolfalse" checked="True" label="Does the dataset contain header:" />
+    <param name="header1" type="boolean" optional="True" truevalue="booltrue" falsevalue="boolfalse" checked="False" label="Does the dataset contain header:" />
     <param name="col1" multiple="@MULTIPLE1@" type="data_column" data_ref="infile1" label="Select target column(s):"/>
     <param name="infile2" type="data" format="tabular" label="Dataset containing class labels:"/>
-    <param name="header2" type="boolean" optional="True" truevalue="booltrue" falsevalue="boolfalse" checked="True" label="Does the dataset contain header:" />
+    <param name="header2" type="boolean" optional="True" truevalue="booltrue" falsevalue="boolfalse" checked="False" label="Does the dataset contain header:" />
     <param name="col2" multiple="@MULTIPLE2@" type="data_column" data_ref="infile2" label="Select target column(s):"/>
     <yield/>
   </xml>


### PR DESCRIPTION
User is able to choose whether the input carry header or not. Support tabular data type only.