### PR TITLE
Fix no reference available issue in VT normalize

### DIFF
--- a/tools/vt/vt_normalize.xml
+++ b/tools/vt/vt_normalize.xml
@@ -57,7 +57,7 @@
             <when value="cached">
                 <param name="reference_genome" type="select" label="Using reference genome">
                     <options from_data_table="fasta_indexes">
-                        <filter type="data_meta" ref="infile" key="dbkey" column="1" />
+                        <filter type="sort_by" column="2" />
                         <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
                     </options>
                 </param>


### PR DESCRIPTION
Hi, found this bug when trying out this tool somebody wants to use on our server.
Apparently it could not find the references that were in the fasta_indexes table. So I checked BWA from IUC how they did it, updated the xml on the server and it worked.
So here is the bug fix.