### PR TITLE
Bismark datatype, fixes upto and stdout

### DIFF
--- a/tools/bismark/bismark_mapping/bismark_bowtie2_wrapper.xml
+++ b/tools/bismark/bismark_mapping/bismark_bowtie2_wrapper.xml
@@ -282,11 +282,11 @@
                 </action>
               </when>
             </conditional>
-            <change_format>
-              <when input="sort_bam" value="true" format='bam'/>
-              <when input="sort_bam" value="false" format='qname_input_sorted.bam'/>
-            </change_format>
           </actions>
+          <change_format>
+            <when input="sort_bam" value="true" format='bam'/>
+            <when input="sort_bam" value="false" format='qname_input_sorted.bam'/>
+          </change_format>
         </data>
 
     	<data format="fastq" name="output_suppressed_reads_l" label="${tool.name} on ${on_string}: suppressed reads (L)">

--- a/tools/bismark/bismark_mapping/bismark_bowtie2_wrapper.xml
+++ b/tools/bismark/bismark_mapping/bismark_bowtie2_wrapper.xml
@@ -282,6 +282,10 @@
                 </action>
               </when>
             </conditional>
+            <change_format>
+              <when input="sort_bam" value="true" format='bam'/>
+              <when input="sort_bam" value="false" format='qname_input_sorted.bam'/>
+            </change_format>
           </actions>
         </data>
 

--- a/tools/bismark/bismark_mapping/bismark_wrapper.py
+++ b/tools/bismark/bismark_mapping/bismark_wrapper.py
@@ -321,18 +321,18 @@ def __main__():
         """
             merge all bam files
         """
-        #tmp_out = tempfile.NamedTemporaryFile( dir=output_dir ).name
-        tmp_stdout = open( tmp_out, 'wab' )
-        #tmp_err = tempfile.NamedTemporaryFile( dir=output_dir ).name
-        tmp_stderr = open( tmp_err, 'wab' )
 
         tmp_res = tempfile.NamedTemporaryFile( dir= output_dir).name
 
         bam_files = glob( os.path.join( output_dir, '*.bam') )
         if len( bam_files ) > 1:
+
+            #reopens tmp output files for append
+            tmp_stdout = open( tmp_out, 'ab' )
+            tmp_stderr = open( tmp_err, 'ab' )
             cmd = 'samtools merge -@ %s -f %s %s ' % ( args.num_threads, tmp_res, ' '.join( bam_files ) )
 
-            proc = subprocess.Popen( args=shlex.split( cmd ), stdout=subprocess.PIPE )
+            proc = subprocess.Popen( args=shlex.split( cmd ), stdout=tmp_stdout, stderr=tmp_stderr )
 
             returncode = proc.wait()
             tmp_stdout.close()

--- a/tools/bismark/bismark_mapping/bismark_wrapper.py
+++ b/tools/bismark/bismark_mapping/bismark_wrapper.py
@@ -243,7 +243,7 @@ def __main__():
     if args.skip_reads:
         additional_opts += ' --skip %s ' % args.skip_reads
     if args.qupto:
-        additional_opts += ' --qupto %s ' % args.qupto
+        additional_opts += ' --upto %s ' % args.qupto
     if args.phred64:
         additional_opts += ' --phred64-quals '
     if args.suppress_header:


### PR DESCRIPTION
These fixes keep galaxy from trying to index the unsorted bam file produced by bismark.
Also fixes a stdout capture (w mode overwrites), and --upto support