### PR TITLE
add column selector options for dataset input - able to input dataset without column selection

### DIFF
--- a/tools/sklearn/clf_metrics.xml
+++ b/tools/sklearn/clf_metrics.xml
@@ -27,18 +27,30 @@ input_json_path = sys.argv[1]
 params = json.load(open(input_json_path, "r"))
 
 header='infer' if params["clf_metrics"].get("header1", None) else None
+column_option = params["clf_metrics"]["column_selector_options_1"]["selected_column_selector_option"]
+if column_option == "by_index_number":
+    c = params["clf_metrics"]["column_selector_options_1"]["col1"]
+else:
+    c = None
 y_t = read_columns(
         "$clf_metrics.infile1",
-        "$clf_metrics.col1",
+        c = c,
+        c_option = column_option,
         sep='\t',
         header=header,
         parse_dates=True
 )
 
 header='infer' if params["clf_metrics"].get("header2", None) else None
+column_option = params["clf_metrics"]["column_selector_options_2"]["selected_column_selector_option2"]
+if column_option == "by_index_number":
+    c = params["clf_metrics"]["column_selector_options_2"]["col2"]
+else:
+    c = None
 y_p = read_columns(
         "$clf_metrics.infile2",
-        "$clf_metrics.col2",
+        c = c,
+        c_option = column_option,
         sep='\t',
         header=header,
         parse_dates=True

--- a/tools/sklearn/ensemble.xml
+++ b/tools/sklearn/ensemble.xml
@@ -49,9 +49,15 @@ if "min_samples_split" in options and options["min_samples_split"] > 1.0:
 input_type = params["selected_tasks"]["selected_algorithms"]["input_options"]["selected_input"]
 if input_type=="tabular":
     header = 'infer' if params["selected_tasks"]["selected_algorithms"]["input_options"]["header1"] else None
+    column_option = params["selected_tasks"]["selected_algorithms"]["input_options"]["column_selector_options_1"]["selected_column_selector_option"]
+    if column_option == "by_index_number":
+        c = params["selected_tasks"]["selected_algorithms"]["input_options"]["column_selector_options_1"]["col1"]
+    else:
+        c = None
     X = read_columns(
             "$selected_tasks.selected_algorithms.input_options.infile1",
-            "$selected_tasks.selected_algorithms.input_options.col1",
+            c = c,
+            c_option = column_option,
             sep='\t',
             header=header,
             parse_dates=True
@@ -60,9 +66,15 @@ else:
     X = mmread(open("$selected_tasks.selected_algorithms.input_options.infile1", 'r'))
 
 header = 'infer' if params["selected_tasks"]["selected_algorithms"]["input_options"]["header2"] else None
+column_option = params["selected_tasks"]["selected_algorithms"]["input_options"]["column_selector_options_2"]["selected_column_selector_option2"]
+if column_option == "by_index_number":
+    c = params["selected_tasks"]["selected_algorithms"]["input_options"]["column_selector_options_2"]["col2"]
+else:
+    c = None
 y = read_columns(
         "$selected_tasks.selected_algorithms.input_options.infile2",
-        "$selected_tasks.selected_algorithms.input_options.col2",
+        c = c,
+        c_option = column_option,
         sep='\t',
         header=header,
         parse_dates=True
@@ -262,7 +274,7 @@ res.to_csv(path_or_buf = "$outfile_predict", sep="\t", index=False)
             <param name="infile1" value="regression_X.tabular" ftype="tabular"/>
             <param name="infile2" value="regression_y.tabular" ftype="tabular"/>
             <param name="header1" value="True"/>
-            <param name="col1" value="1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17"/>
+            <param name="selected_column_selector_option" value="all_columns"/>
             <param name="header2" value="True"/>
             <param name="col2" value="1"/>
             <param name="selected_task" value="train"/>

--- a/tools/sklearn/feature_selection.xml
+++ b/tools/sklearn/feature_selection.xml
@@ -35,10 +35,15 @@ features_has_header = params["input_options"]["header1"]
 input_type = params["input_options"]["selected_input"]
 if input_type=="tabular":
     header = 'infer' if features_has_header else None
-    header = 'infer' if params["input_options"]["header1"] else None
+    column_option = params["input_options"]["column_selector_options_1"]["selected_column_selector_option"]
+    if column_option == "by_index_number":
+        c = params["input_options"]["column_selector_options_1"]["col1"]
+    else:
+        c = None
     X, input_df = read_columns(
             "$input_options.infile1",
-            "$input_options.col1",
+            c = c,
+            c_option = column_option,
             return_df = True,
             sep='\t',
             header=header,
@@ -49,9 +54,15 @@ else:
 
 ## Read labels
 header = 'infer' if params["input_options"]["header2"] else None
+column_option = params["input_options"]["column_selector_options_2"]["selected_column_selector_option2"]
+if column_option == "by_index_number":
+    c = params["input_options"]["column_selector_options_2"]["col2"]
+else:
+    c = None
 y = read_columns(
         "$input_options.infile2",
-        "$input_options.col2",
+        c = c,
+        c_option = column_option,
         sep='\t',
         header=header,
         parse_dates=True

--- a/tools/sklearn/generalized_linear.xml
+++ b/tools/sklearn/generalized_linear.xml
@@ -34,9 +34,15 @@ options = params["selected_tasks"]["selected_algorithms"]["options"]
 
 #if $selected_tasks.selected_algorithms.input_options.selected_input=="tabular":
 header = 'infer' if params["selected_tasks"]["selected_algorithms"]["input_options"]["header1"] else None
+column_option = params["selected_tasks"]["selected_algorithms"]["input_options"]["column_selector_options_1"]["selected_column_selector_option"]
+if column_option == "by_index_number":
+    c = params["selected_tasks"]["selected_algorithms"]["input_options"]["column_selector_options_1"]["col1"]
+else:
+    c = None
 X = read_columns(
         "$selected_tasks.selected_algorithms.input_options.infile1",
-        "$selected_tasks.selected_algorithms.input_options.col1",
+        c = c,
+        c_option = column_option,
         sep='\t',
         header=header,
         parse_dates=True
@@ -46,9 +52,15 @@ X = mmread(open("$selected_tasks.selected_algorithms.input_options.infile1", 'r'
 #end if
 
 header = 'infer' if params["selected_tasks"]["selected_algorithms"]["input_options"]["header2"] else None
+column_option = params["selected_tasks"]["selected_algorithms"]["input_options"]["column_selector_options_2"]["selected_column_selector_option2"]
+if column_option == "by_index_number":
+    c = params["selected_tasks"]["selected_algorithms"]["input_options"]["column_selector_options_2"]["col2"]
+else:
+    c = None
 y = read_columns(
         "$selected_tasks.selected_algorithms.input_options.infile2",
-        "$selected_tasks.selected_algorithms.input_options.col2",
+        c = c,
+        c_option = column_option,
         sep='\t',
         header=header,
         parse_dates=True

--- a/tools/sklearn/main_macros.xml
+++ b/tools/sklearn/main_macros.xml
@@ -2,12 +2,11 @@
   <token name="@VERSION@">0.9</token>
 
   <token name="@COLUMNS_FUNCTION@">
-def read_columns(f, c, return_df=False, **args):
+def read_columns(f, c=None, c_option='by_index_number', return_df=False, **args):
   data = pandas.read_csv(f, **args)
-  cols = c.split (',')
-  cols = map(int, cols)
-  cols = list(map(lambda x: x - 1, cols))
-  data = data.iloc[:,cols]
+  if c_option == 'by_index_number':
+    cols = list(map(lambda x: x - 1, c))
+    data = data.iloc[:,cols]
   y = data.values
   if return_df:
     return y, data
@@ -17,7 +16,6 @@ def read_columns(f, c, return_df=False, **args):
   </token>
 
 ## generate an instance for one of sklearn.feature_selection classes
-## must call "@COLUMNS_FUNCTION@"
   <token name="@FEATURE_SELECTOR_FUNCTION@">
 def feature_selector(inputs):
   selector = inputs["selected_algorithm"]
@@ -428,14 +426,35 @@ def feature_selector(inputs):
     <yield/>
   </xml>
 
-  <xml name="samples_tabular" token_multiple1="False" token_multiple2="False">
+  <xml name="samples_tabular" token_multiple1="false" token_multiple2="false">
     <param name="infile1" type="data" format="tabular" label="Training samples dataset:"/>
-    <param name="header1" type="boolean" optional="True" truevalue="booltrue" falsevalue="boolfalse" checked="False" label="Does the dataset contain header:" />
-    <param name="col1" multiple="@MULTIPLE1@" type="data_column" data_ref="infile1" label="Select target column(s):"/>
+    <param name="header1" type="boolean" optional="true" truevalue="booltrue" falsevalue="boolfalse" checked="False" label="Does the dataset contain header:" />
+    <conditional name="column_selector_options_1">
+      <expand macro="samples_column_selector_options" multiple="@MULTIPLE1@"/>
+    </conditional>
     <param name="infile2" type="data" format="tabular" label="Dataset containing class labels:"/>
-    <param name="header2" type="boolean" optional="True" truevalue="booltrue" falsevalue="boolfalse" checked="False" label="Does the dataset contain header:" />
-    <param name="col2" multiple="@MULTIPLE2@" type="data_column" data_ref="infile2" label="Select target column(s):"/>
+    <param name="header2" type="boolean" optional="true" truevalue="booltrue" falsevalue="boolfalse" checked="False" label="Does the dataset contain header:" />
+    <conditional name="column_selector_options_2">
+      <expand macro="samples_column_selector_options" column_option="selected_column_selector_option2" col_name="col2" multiple="@MULTIPLE2@" infile="infile2"/>
+    </conditional>
     <yield/>
+  </xml>
+
+  <xml name="samples_column_selector_options" token_column_option="selected_column_selector_option" token_col_name="col1" token_multiple="False" token_infile="infile1">
+    <param name="@COLUMN_OPTION@" type="select" label="Choose how to select data by column:">
+      <option value="by_index_number" selected="true">Select columns by column index number(s)</option>
+      <!--
+      <option value="by_header_name">Select columns by column header name(s)</option>
+      <option value="all_but_by_index_number">All columns but by column index number(s)</option>
+      <option value="all_but_by_header_name">All columns but by column header name(s)</option> 
+      -->
+      <option value="all_columns">All columns</option>
+    </param>
+    <when value="by_index_number">
+      <param name="@COL_NAME@" multiple="@MULTIPLE@" type="data_column" data_ref="@INFILE@" label="Select target column(s):"/>
+    </when>
+    <when value="all_columns">
+    </when>
   </xml>
 
   <xml name="clf_inputs_extended" token_label1=" " token_label2=" " token_multiple="False">
@@ -470,10 +489,14 @@ def feature_selector(inputs):
   <xml name="clf_inputs" token_label1="Dataset containing true labels (tabular):" token_label2="Dataset containing predicted values (tabular):" token_multiple1="False" token_multiple="False">
     <param name="infile1" type="data" format="tabular" label="@LABEL1@"/>
     <param name="header1" type="boolean" optional="True" truevalue="booltrue" falsevalue="boolfalse" checked="False" label="Does the dataset contain header:" />
-    <param name="col1" multiple="@MULTIPLE1@" type="data_column" data_ref="infile1" label="Select the target column:"/>
+    <conditional name="column_selector_options_1">
+      <expand macro="samples_column_selector_options" multiple="@MULTIPLE1@"/>
+    </conditional>
     <param name="infile2" type="data" format="tabular" label="@LABEL2@"/>
     <param name="header2" type="boolean" optional="True" truevalue="booltrue" falsevalue="boolfalse" checked="False" label="Does the dataset contain header:" />
-    <param name="col2" multiple="@MULTIPLE@" type="data_column" data_ref="infile2" label="Select target column(s):"/>
+    <conditional name="column_selector_options_2">
+      <expand macro="samples_column_selector_options" col_name="col2" multiple="@MULTIPLE@" infile="infile2"/>
+    </conditional>
   </xml>
 
   <xml name="multiple_input" token_name="input_files" token_max_num="10" token_format="txt" token_label="Sparse matrix file (.mtx, .txt)" token_help_text="Specify a sparse matrix file in .txt format.">

--- a/tools/sklearn/main_macros.xml
+++ b/tools/sklearn/main_macros.xml
@@ -495,7 +495,7 @@ def feature_selector(inputs):
     <param name="infile2" type="data" format="tabular" label="@LABEL2@"/>
     <param name="header2" type="boolean" optional="True" truevalue="booltrue" falsevalue="boolfalse" checked="False" label="Does the dataset contain header:" />
     <conditional name="column_selector_options_2">
-      <expand macro="samples_column_selector_options" col_name="col2" multiple="@MULTIPLE@" infile="infile2"/>
+      <expand macro="samples_column_selector_options" column_option="selected_column_selector_option2" col_name="col2" multiple="@MULTIPLE@" infile="infile2"/>
     </conditional>
   </xml>
 

--- a/tools/sklearn/model_validation.xml
+++ b/tools/sklearn/model_validation.xml
@@ -35,9 +35,15 @@ params = json.load(open(input_json_path, "r"))
 input_type = params["input_options"]["selected_input"]
 if input_type=="tabular":
     header = 'infer' if params["input_options"]["header1"] else None
+    column_option = params["input_options"]["column_selector_options_1"]["selected_column_selector_option"]
+    if column_option == "by_index_number":
+        c = params["input_options"]["column_selector_options_1"]["col1"]
+    else:
+        c = None
     X = read_columns(
             "$input_options.infile1",
-            "$input_options.col1",
+            c = c,
+            c_option = column_option,
             sep='\t',
             header=header,
             parse_dates=True
@@ -46,9 +52,15 @@ else:
     X = mmread(open("$input_options.infile1", 'r'))
 
 header = 'infer' if params["input_options"]["header2"] else None
+column_option = params["input_options"]["column_selector_options_2"]["selected_column_selector_option2"]
+if column_option == "by_index_number":
+    c = params["input_options"]["column_selector_options_2"]["col2"]
+else:
+    c = None
 y = read_columns(
         "$input_options.infile2",
-        "$input_options.col2",
+        c = c,
+        c_option = column_option,
         sep='\t',
         header=header,
         parse_dates=True
@@ -318,7 +330,7 @@ else:
             <param name="has_estimator" value="yes"/>
             <param name="infile1" value="regression_X.tabular" ftype="tabular"/>
             <param name="header1" value="true" />
-            <param name="col1" value="1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17"/>
+            <param name="selected_column_selector_option" value="all_columns"/>
             <param name="infile2" value="regression_y.tabular" ftype="tabular"/>
             <param name="header2" value="true" />
             <param name="col2" value="1"/>
@@ -336,10 +348,10 @@ else:
             <param name="return_type" value="best_score_"/>
             <param name="infile1" value="regression_X.tabular" ftype="tabular"/>
             <param name="header1" value="true" />
-            <param name="col1" value="1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17"/>
+            <param name="selected_column_selector_option" value="all_columns"/>
             <param name="infile2" value="regression_y.tabular" ftype="tabular"/>
             <param name="header2" value="true" />
-            <param name="col2" value="1"/>
+            <param name="selected_column_selector_option2" value="all_columns"/>
             <output name="outfile" file="mv_result07.tabular"/>
         </test>
     </tests>

--- a/tools/sklearn/regression_metrics.xml
+++ b/tools/sklearn/regression_metrics.xml
@@ -27,18 +27,30 @@ input_json_path = sys.argv[1]
 params = json.load(open(input_json_path, "r"))
 
 header='infer' if params["regression_metrics"]["header1"] else None
+column_option = params["regression_metrics"]["column_selector_options_1"]["selected_column_selector_option"]
+if column_option == "by_index_number":
+    c = params["regression_metrics"]["column_selector_options_1"]["col1"]
+else:
+    c = None
 y_t = read_columns(
         "$regression_metrics.infile1",
-        "$regression_metrics.col1",
+        c = c,
+        c_option = column_option,
         sep='\t',
         header=header,
         parse_dates=True
 )
 
 header='infer' if params["regression_metrics"]["header2"] else None
+column_option = params["regression_metrics"]["column_selector_options_2"]["selected_column_selector_option2"]
+if column_option == "by_index_number":
+    c = params["regression_metrics"]["column_selector_options_2"]["col2"]
+else:
+    c = None
 y_p = read_columns(
         "$regression_metrics.infile2",
-        "$regression_metrics.col2",
+        c = c,
+        c_option = column_option,
         sep='\t',
         header=header,
         parse_dates=True


### PR DESCRIPTION
Provide multiple options on how to select data by column.
Choose `All columns` to skip column selection. 