### PR TITLE
add all-columns-but-by-index-number option to sklearn column selector

### DIFF
--- a/tools/sklearn/clf_metrics.xml
+++ b/tools/sklearn/clf_metrics.xml
@@ -28,7 +28,7 @@ params = json.load(open(input_json_path, "r"))
 
 header='infer' if params["clf_metrics"].get("header1", None) else None
 column_option = params["clf_metrics"]["column_selector_options_1"]["selected_column_selector_option"]
-if column_option == "by_index_number":
+if column_option in ["by_index_number", "all_but_by_index_number"]:
     c = params["clf_metrics"]["column_selector_options_1"]["col1"]
 else:
     c = None
@@ -43,7 +43,7 @@ y_t = read_columns(
 
 header='infer' if params["clf_metrics"].get("header2", None) else None
 column_option = params["clf_metrics"]["column_selector_options_2"]["selected_column_selector_option2"]
-if column_option == "by_index_number":
+if column_option in ["by_index_number", "all_but_by_index_number"]:
     c = params["clf_metrics"]["column_selector_options_2"]["col2"]
 else:
     c = None

--- a/tools/sklearn/ensemble.xml
+++ b/tools/sklearn/ensemble.xml
@@ -50,7 +50,7 @@ input_type = params["selected_tasks"]["selected_algorithms"]["input_options"]["s
 if input_type=="tabular":
     header = 'infer' if params["selected_tasks"]["selected_algorithms"]["input_options"]["header1"] else None
     column_option = params["selected_tasks"]["selected_algorithms"]["input_options"]["column_selector_options_1"]["selected_column_selector_option"]
-    if column_option == "by_index_number":
+    if column_option in ["by_index_number", "all_but_by_index_number"]:
         c = params["selected_tasks"]["selected_algorithms"]["input_options"]["column_selector_options_1"]["col1"]
     else:
         c = None
@@ -67,7 +67,7 @@ else:
 
 header = 'infer' if params["selected_tasks"]["selected_algorithms"]["input_options"]["header2"] else None
 column_option = params["selected_tasks"]["selected_algorithms"]["input_options"]["column_selector_options_2"]["selected_column_selector_option2"]
-if column_option == "by_index_number":
+if column_option in ["by_index_number", "all_but_by_index_number"]:
     c = params["selected_tasks"]["selected_algorithms"]["input_options"]["column_selector_options_2"]["col2"]
 else:
     c = None

--- a/tools/sklearn/feature_selection.xml
+++ b/tools/sklearn/feature_selection.xml
@@ -36,7 +36,7 @@ input_type = params["input_options"]["selected_input"]
 if input_type=="tabular":
     header = 'infer' if features_has_header else None
     column_option = params["input_options"]["column_selector_options_1"]["selected_column_selector_option"]
-    if column_option == "by_index_number":
+    if column_option in ["by_index_number", "all_but_by_index_number"]:
         c = params["input_options"]["column_selector_options_1"]["col1"]
     else:
         c = None
@@ -55,7 +55,7 @@ else:
 ## Read labels
 header = 'infer' if params["input_options"]["header2"] else None
 column_option = params["input_options"]["column_selector_options_2"]["selected_column_selector_option2"]
-if column_option == "by_index_number":
+if column_option in ["by_index_number", "all_but_by_index_number"]:
     c = params["input_options"]["column_selector_options_2"]["col2"]
 else:
     c = None

--- a/tools/sklearn/generalized_linear.xml
+++ b/tools/sklearn/generalized_linear.xml
@@ -35,7 +35,7 @@ options = params["selected_tasks"]["selected_algorithms"]["options"]
 #if $selected_tasks.selected_algorithms.input_options.selected_input=="tabular":
 header = 'infer' if params["selected_tasks"]["selected_algorithms"]["input_options"]["header1"] else None
 column_option = params["selected_tasks"]["selected_algorithms"]["input_options"]["column_selector_options_1"]["selected_column_selector_option"]
-if column_option == "by_index_number":
+if column_option in ["by_index_number", "all_but_by_index_number"]:
     c = params["selected_tasks"]["selected_algorithms"]["input_options"]["column_selector_options_1"]["col1"]
 else:
     c = None
@@ -53,7 +53,7 @@ X = mmread(open("$selected_tasks.selected_algorithms.input_options.infile1", 'r'
 
 header = 'infer' if params["selected_tasks"]["selected_algorithms"]["input_options"]["header2"] else None
 column_option = params["selected_tasks"]["selected_algorithms"]["input_options"]["column_selector_options_2"]["selected_column_selector_option2"]
-if column_option == "by_index_number":
+if column_option in ["by_index_number", "all_but_by_index_number"]:
     c = params["selected_tasks"]["selected_algorithms"]["input_options"]["column_selector_options_2"]["col2"]
 else:
     c = None
@@ -240,7 +240,8 @@ res.to_csv(path_or_buf = "$outfile_predict", sep="\t", index=False, header=None)
         <test>
             <param name="infile1" value="regression_train.tabular" ftype="tabular"/>
             <param name="infile2" value="regression_train.tabular" ftype="tabular"/>
-            <param name="col1" value="1,2,3,4,5"/>
+            <param name="selected_column_selector_option" value="all_but_by_index_number"/>
+            <param name="col1" value="6"/>
             <param name="col2" value="6"/>
             <param name="selected_task" value="train"/>
             <param name="selected_algorithm" value="SGDRegressor"/>

--- a/tools/sklearn/main_macros.xml
+++ b/tools/sklearn/main_macros.xml
@@ -7,6 +7,9 @@ def read_columns(f, c=None, c_option='by_index_number', return_df=False, **args)
   if c_option == 'by_index_number':
     cols = list(map(lambda x: x - 1, c))
     data = data.iloc[:,cols]
+  if c_option == 'all_but_by_index_number':
+    cols = list(map(lambda x: x - 1, c))
+    data.drop(data.columns[cols], axis=1, inplace=True)
   y = data.values
   if return_df:
     return y, data
@@ -443,14 +446,15 @@ def feature_selector(inputs):
   <xml name="samples_column_selector_options" token_column_option="selected_column_selector_option" token_col_name="col1" token_multiple="False" token_infile="infile1">
     <param name="@COLUMN_OPTION@" type="select" label="Choose how to select data by column:">
       <option value="by_index_number" selected="true">Select columns by column index number(s)</option>
-      <!--
-      <option value="by_header_name">Select columns by column header name(s)</option>
+      <!--<option value="by_header_name">Select columns by column header name(s)</option>-->
       <option value="all_but_by_index_number">All columns but by column index number(s)</option>
-      <option value="all_but_by_header_name">All columns but by column header name(s)</option> 
-      -->
+      <!--<option value="all_but_by_header_name">All columns but by column header name(s)</option> -->
       <option value="all_columns">All columns</option>
     </param>
     <when value="by_index_number">
+      <param name="@COL_NAME@" multiple="@MULTIPLE@" type="data_column" data_ref="@INFILE@" label="Select target column(s):"/>
+    </when>
+    <when value="all_but_by_index_number">
       <param name="@COL_NAME@" multiple="@MULTIPLE@" type="data_column" data_ref="@INFILE@" label="Select target column(s):"/>
     </when>
     <when value="all_columns">

--- a/tools/sklearn/model_validation.xml
+++ b/tools/sklearn/model_validation.xml
@@ -36,7 +36,7 @@ input_type = params["input_options"]["selected_input"]
 if input_type=="tabular":
     header = 'infer' if params["input_options"]["header1"] else None
     column_option = params["input_options"]["column_selector_options_1"]["selected_column_selector_option"]
-    if column_option == "by_index_number":
+    if column_option in ["by_index_number", "all_but_by_index_number"]:
         c = params["input_options"]["column_selector_options_1"]["col1"]
     else:
         c = None
@@ -53,7 +53,7 @@ else:
 
 header = 'infer' if params["input_options"]["header2"] else None
 column_option = params["input_options"]["column_selector_options_2"]["selected_column_selector_option2"]
-if column_option == "by_index_number":
+if column_option in ["by_index_number", "all_but_by_index_number"]:
     c = params["input_options"]["column_selector_options_2"]["col2"]
 else:
     c = None

--- a/tools/sklearn/regression_metrics.xml
+++ b/tools/sklearn/regression_metrics.xml
@@ -28,7 +28,7 @@ params = json.load(open(input_json_path, "r"))
 
 header='infer' if params["regression_metrics"]["header1"] else None
 column_option = params["regression_metrics"]["column_selector_options_1"]["selected_column_selector_option"]
-if column_option == "by_index_number":
+if column_option in ["by_index_number", "all_but_by_index_number"]:
     c = params["regression_metrics"]["column_selector_options_1"]["col1"]
 else:
     c = None
@@ -43,7 +43,7 @@ y_t = read_columns(
 
 header='infer' if params["regression_metrics"]["header2"] else None
 column_option = params["regression_metrics"]["column_selector_options_2"]["selected_column_selector_option2"]
-if column_option == "by_index_number":
+if column_option in ["by_index_number", "all_but_by_index_number"]:
     c = params["regression_metrics"]["column_selector_options_2"]["col2"]
 else:
     c = None
@@ -167,7 +167,8 @@ with open("$outfile", 'w+') as out_file:
             <param name="selected_metric" value="median_absolute_error"/>
             <param name="infile1" value="regression_test_y.tabular" ftype="tabular"/>
             <param name="header1" value="True"/>
-            <param name="col1" value="1"/>
+            <param name="selected_column_selector_option" value="all_but_by_index_number"/>
+            <param name="col1" value="2"/>
             <param name="infile2" value="regression_test_y.tabular" ftype="tabular"/>
             <param name="header2" value="True"/>
             <param name="col2" value="2"/>
@@ -180,7 +181,8 @@ with open("$outfile", 'w+') as out_file:
             <param name="col1" value="1"/>
             <param name="infile2" value="regression_test_y.tabular" ftype="tabular"/>
             <param name="header2" value="True"/>
-            <param name="col2" value="2"/>
+            <param name="selected_column_selector_option2" value="all_but_by_index_number"/>
+            <param name="col2" value="1"/>
             <output name="outfile" file="regression_metrics_result06"/>
         </test>
     </tests>


### PR DESCRIPTION
Imagine there are hundreds or even thousands of features in the input dataset (e.g. RNAseq data) and only several columns, either index or labels, need be excluded from the column selection. This PR works perfectly for this kind of scenario. 