### PR TITLE
Racon: Changed interval to tabular input format

### DIFF
--- a/tools/racon/racon.xml
+++ b/tools/racon/racon.xml
@@ -35,7 +35,7 @@
     ]]></command>
     <inputs>
         <param type="data" name="reads" format="fasta,fasta.gz,fastq,fastq.gz" label="Sequences"/>
-        <param type="data" name="overlaps" format="sam,interval" label="Overlaps"/>
+        <param type="data" name="overlaps" format="sam,tabular" label="Overlaps"/>
         <param type="data" name="corrected_reads" format="fasta,fasta.gz,fastq,fastq.gz" label="Target sequences"/>
 
         <param argument="-u" type="boolean" truevalue="-u" falsevalue="" label="output unpolished target sequences" />


### PR DESCRIPTION
Changed the format from interval to tabular, this makes it able to use the newest minimap2 output.