### PR TITLE
Chipseeker: fix for tabular output

### DIFF
--- a/tools/chipseeker/chipseeker.R
+++ b/tools/chipseeker/chipseeker.R
@@ -58,9 +58,9 @@ if (format == "interval") {
                     End=res$end,
                     Comment=metacols)
 } else {
-    resout <- data.frame(Chrom=res$seqnames,
-                    Start=res$start - 1,
-                    End=res$end,
+    resout <- data.frame(res$seqnames,
+                    res$start - 1,
+                    res$end,
                     metacols)
 }
 

--- a/tools/chipseeker/chipseeker.R
+++ b/tools/chipseeker/chipseeker.R
@@ -53,17 +53,18 @@ metacols <- res[, c(7:ncol(res), 1)]
 # Convert from 1-based to 0-based format
 if (format == "interval") {
     metacols <- apply(as.data.frame(metacols), 1, function(col) paste(col, collapse="|"))
-    resout <- data.frame(Chrom=res$seqnames,
-                    Start=res$start - 1,
-                    End=res$end,
-                    Comment=metacols)
+    resout <- data.frame(res$seqnames,
+                    res$start - 1,
+                    res$end,
+                    metacols)
+    colnames(resout)[1:4] <- c("Chrom", "Start", "End", "Comment")
 } else {
     resout <- data.frame(res$seqnames,
                     res$start - 1,
                     res$end,
                     metacols)
+    colnames(resout)[1:3] <- c("Chrom", "Start", "End")
 }
-
 write.table(resout, file="out.tab", sep="\t", row.names=FALSE, quote=FALSE)
 
 if (!is.null(args$plots)) {

--- a/tools/chipseeker/chipseeker.xml
+++ b/tools/chipseeker/chipseeker.xml
@@ -1,4 +1,4 @@
-<tool id="chipseeker" name="ChIPseeker" version="1.14.2.2">
+<tool id="chipseeker" name="ChIPseeker" version="1.14.2.3">
     <description>for ChIP peak annotation and visualization</description>
     <requirements>
         <requirement type="package" version="1.14.2">bioconductor-chipseeker</requirement>

--- a/tools/chipseeker/chipseeker.xml
+++ b/tools/chipseeker/chipseeker.xml
@@ -1,7 +1,7 @@
-<tool id="chipseeker" name="ChIPseeker" version="1.14.2.3">
+<tool id="chipseeker" name="ChIPseeker" version="1.16.1">
     <description>for ChIP peak annotation and visualization</description>
     <requirements>
-        <requirement type="package" version="1.14.2">bioconductor-chipseeker</requirement>
+        <requirement type="package" version="1.16.1">bioconductor-chipseeker</requirement>
         <requirement type="package" version="1.4.4">r-optparse</requirement>
     </requirements>
     <version_command><![CDATA[


### PR DESCRIPTION
This is a fix for the tabular output headings, which currently has one of the peaks inserted e.g.:

`Chrom | Start | End | CDK12ChIP_bam_peak_1 | X17 | . | X2.39678 | X4.90017 | X1.75442 | X19 | annotation | geneChr | geneStart | geneEnd | geneLength | geneStrand | transcriptId | distanceToTSS | geneName | geneId`

this changes it to:

`Chrom | Start | End | V4 | V5 | V6 | V7 | V8 | V9 | V10 | annotation | geneChr | geneStart | geneEnd | geneLength | geneStrand | transcriptId | distanceToTSS | geneName | geneId`

(the V4 -V10 headings are due to R's naming, as there are no headings in the bed file input)




