### PR TITLE
Canu: append M to Galaxy Memory MB and bump to 1.8

### DIFF
--- a/tools/canu/canu.xml
+++ b/tools/canu/canu.xml
@@ -46,10 +46,10 @@
         obtovlThreads=\${GALAXY_SLOTS:-4}
         utgovlThreads=\${GALAXY_SLOTS:-4}
         batThreads=\${GALAXY_SLOTS:-4}
-        batMemory=\${GALAXY_MEMORY_MB:-7}M
-        cormhapMemory=\${GALAXY_MEMORY_MB:-7}M
-        obtovlMemory=\${GALAXY_MEMORY_MB:-7}M
-        utgovlMemory=\${GALAXY_MEMORY_MB:-7}M
+        batMemory=\${GALAXY_MEMORY_MB:-4096}M
+        cormhapMemory=\${GALAXY_MEMORY_MB:-4096}M
+        obtovlMemory=\${GALAXY_MEMORY_MB:-4096}M
+        utgovlMemory=\${GALAXY_MEMORY_MB:-4096}M
         gfaThreads=\${GALAXY_SLOTS:-4}
         corThreads=\${GALAXY_SLOTS:-4}
         cnsThreads=\${GALAXY_SLOTS:-4}

--- a/tools/canu/canu.xml
+++ b/tools/canu/canu.xml
@@ -1,7 +1,7 @@
-<tool id="canu" name="Canu assembler" version="1.7">
+<tool id="canu" name="Canu assembler" version="1.8">
     <description>Assembler optimized for long error-prone reads such as PacBio, Oxford Nanopore </description>
     <requirements>
-        <requirement type="package" version="1.7">canu</requirement>
+        <requirement type="package" version="1.8">canu</requirement>
     </requirements>
     <version_command>canu --version</version_command>
     <command detect_errors="exit_code">
@@ -41,16 +41,15 @@
             ${contigFilter.lowCovDepth}
         '
         genomeSize=$genomeSize
-        stopOnReadQuality=false
         minThreads=\${GALAXY_SLOTS:-4}
         maxThreads=\${GALAXY_SLOTS:-4}
         obtovlThreads=\${GALAXY_SLOTS:-4}
         utgovlThreads=\${GALAXY_SLOTS:-4}
         batThreads=\${GALAXY_SLOTS:-4}
-        batMemory=\${GALAXY_MEMORY_MB:-7}
-        cormhapMemory=\${GALAXY_MEMORY_MB:-7}
-        obtovlMemory=\${GALAXY_MEMORY_MB:-7}
-        utgovlMemory=\${GALAXY_MEMORY_MB:-7}
+        batMemory=\${GALAXY_MEMORY_MB:-7}M
+        cormhapMemory=\${GALAXY_MEMORY_MB:-7}M
+        obtovlMemory=\${GALAXY_MEMORY_MB:-7}M
+        utgovlMemory=\${GALAXY_MEMORY_MB:-7}M
         gfaThreads=\${GALAXY_SLOTS:-4}
         corThreads=\${GALAXY_SLOTS:-4}
         cnsThreads=\${GALAXY_SLOTS:-4}

--- a/tools/canu/canu.xml
+++ b/tools/canu/canu.xml
@@ -53,7 +53,6 @@
         gfaThreads=\${GALAXY_SLOTS:-4}
         corThreads=\${GALAXY_SLOTS:-4}
         cnsThreads=\${GALAXY_SLOTS:-4}
-        gnuplotTested=true
         useGrid=false
         $mode
         #for $counter, $input in enumerate($inputs):


### PR DESCRIPTION
Without M the value is taken as gigabyte, and `stopOnReadQuality` has been removed in 1.8.