### PR TITLE
Chipseeker raises error when 'no' is selected in the plots boolean

### DIFF
--- a/tools/chipseeker/chipseeker.xml
+++ b/tools/chipseeker/chipseeker.xml
@@ -1,4 +1,4 @@
-<tool id="chipseeker" name="ChIPseeker" version="1.16.1">
+<tool id="chipseeker" name="ChIPseeker" version="1.16.2">
     <description>for ChIP peak annotation and visualization</description>
     <requirements>
         <requirement type="package" version="1.16.1">bioconductor-chipseeker</requirement>
@@ -30,7 +30,9 @@ echo $(R --version | grep version | grep -v GNU)", ChIPseeker version" $(R --van
             -D $adv.flankgenedist
         #end if
         -f $format
-        -p $pdf
+        #if $pdf:
+            -p $pdf
+        #end if
         -r $rdata
     ]]>
     </command>
@@ -141,6 +143,13 @@ echo $(R --version | grep version | grep -v GNU)", ChIPseeker version" $(R --van
             <param name="format" value="tabular"/>
             <output name="out_tab" ftype="tabular" file="outflank.tab" />
             <output name="out_plots" file="out.pdf" compare="sim_size"/>
+        </test>
+        <!-- Ensure the tool works when no plots are outputed -->
+        <test expect_num_outputs="1">
+            <param name="peaks" value="in.interval" ftype="interval"/>
+            <param name="gtf_source_select" value="cached"/>
+            <param name="pdf" value=""/>
+            <output name="out_tab" ftype="interval" file="outint.int" />
         </test>
     </tests>
     <help><![CDATA[


### PR DESCRIPTION
- Added test to check if the tool runs when no plot output is selected
- Modified wrapper so that the test passes