### PR TITLE
find_and_replace: column splitting bugfix

### DIFF
--- a/tools/text_processing/text_processing/easyjoin.xml
+++ b/tools/text_processing/text_processing/easyjoin.xml
@@ -1,4 +1,4 @@
-<tool id="tp_easyjoin_tool" name="Join" version="@BASE_VERSION@.1">
+<tool id="tp_easyjoin_tool" name="Join" version="@BASE_VERSION@.2">
     <description>two files</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/text_processing/text_processing/easyjoin.xml
+++ b/tools/text_processing/text_processing/easyjoin.xml
@@ -13,7 +13,7 @@
         chmod +x sort-header &&
         perl $__tool_directory__/easyjoin
             $jointype
-            -t '	'
+            -t $'\t'
             $header
             -e '$empty_string_filler'
             -o auto
@@ -29,7 +29,7 @@
         <param name="infile1" format="tabular" type="data" label="1st file" />
         <param name="column1" label="Column to use from 1st file" type="data_column" data_ref="infile1" accept_default="true" />
 
-        <param name="infile2" format="txt" type="data" label="2nd File" />
+        <param name="infile2" format="tabular" type="data" label="2nd File" />
         <param name="column2" label="Column to use from 2nd file" type="data_column" data_ref="infile2" accept_default="true" />
 
         <param name="jointype" type="select" label="Output lines appearing in">

--- a/tools/text_processing/text_processing/find_and_replace
+++ b/tools/text_processing/text_processing/find_and_replace
@@ -65,7 +65,7 @@ if ( $find_in_specific_column ) {
 	$perl_program = <<EOF;
 	while ( <STDIN> ) {
 		chomp ;
-		my \@columns = split ;
+		my \@columns = split /\t/;
 
 		#not enough columns in this line - skip it
 		next if ( \@columns < $find_in_specific_column ) ;

--- a/tools/text_processing/text_processing/find_and_replace.xml
+++ b/tools/text_processing/text_processing/find_and_replace.xml
@@ -80,6 +80,23 @@
             <param name="wholewords" value="True" />
             <output name="outfile" file="find_and_replace_results1.txt" />
         </test>
+	<!-- test that columns are split by tab not space. input has no tab loads of spaces 
+	     .. therefore the ftype needs to be set. 
+             result should be the same as in test 1 which works on whole line -->
+        <test>
+            <param name="infile" value="find_and_replace1.txt" ftype="tabular" />
+            <param name="find_pattern" value="day" />
+            <param name="replace_pattern" value="great day" />
+            <param name="is_regex" value="False" />
+            <param name="global" value="true" />
+            <param name="caseinsensitive" value="False" />
+            <param name="wholewords" value="True" />
+            <conditional name="searchwhere">
+                <param name="searchwhere_select" value="column"/>
+                <param name="column" value="1" />
+            </conditional>
+            <output name="outfile" file="find_and_replace_results1.txt" />
+        </test>
         <test>
             <param name="infile" value="find_and_replace2.txt" />
             <param name="find_pattern" value="^chr" />

--- a/tools/text_processing/text_processing/find_and_replace.xml
+++ b/tools/text_processing/text_processing/find_and_replace.xml
@@ -1,4 +1,4 @@
-<tool id="tp_find_and_replace" name="Replace" version="@BASE_VERSION@.2">
+<tool id="tp_find_and_replace" name="Replace" version="@BASE_VERSION@.3">
     <description>parts of text</description>
     <macros>
         <import>macros.xml</import>


### PR DESCRIPTION
perl split defaults to split on any space but we need to split by tab