### PR TITLE
Chipseeker: small fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ jobs:
 
 before_install:
   - export GALAXY_REPO=https://github.com/galaxyproject/galaxy
-  - export GALAXY_RELEASE=release_18.09
+  - export GALAXY_RELEASE=release_19.01
   - export PLANEMO_CONDA_PREFIX="$HOME/conda"
   - unset JAVA_HOME
 
@@ -79,7 +79,7 @@ install:
   - pip install planemo
   - planemo conda_init
   - export PATH="$PLANEMO_CONDA_PREFIX/bin:$PATH"
-  - conda install -y -c conda-forge conda=4.5.12
+  - conda install -y -c conda-forge conda=4.6.14
   - planemo --version
   - conda --version
   - /home/travis/conda/bin/conda create -v -y --override-channels --channel iuc --channel conda-forge --channel bioconda --channel defaults --name mulled-v1-bb17a71839952990a701d9be96e6ded0cc4945e074406f3782c26da156b2e8d7 deepvariant=0.4.1 samtools=1.3.1

--- a/tools/chipseeker/.shed.yml
+++ b/tools/chipseeker/.shed.yml
@@ -6,4 +6,4 @@ long_description: This wrapper implements the ChIPseeker functions to retrieve t
 homepage_url: https://bioconductor.org/packages/release/bioc/html/ChIPseeker.html
 name: chipseeker
 owner: rnateam
-remote_repository_url: https://github.com/galaxyproject/tools-iuc/tree/master/tools/chipseeker
+remote_repository_url: https://github.com/bgruening/galaxytools/tree/master/tools/chipseeker

--- a/tools/chipseeker/chipseeker.R
+++ b/tools/chipseeker/chipseeker.R
@@ -12,6 +12,7 @@ suppressPackageStartupMessages({
 
 option_list <- list(
     make_option(c("-i","--infile"), type="character", help="Peaks file to be annotated"),
+    make_option(c("-H","--header"), type="logical", help="Peaks file contains header row"),
     make_option(c("-G","--gtf"), type="character", help="GTF to create TxDb."),
     make_option(c("-u","--upstream"), type="integer", help="TSS upstream region"),
     make_option(c("-d","--downstream"), type="integer", help="TSS downstream region"),
@@ -51,7 +52,13 @@ if (!is.null(args$ignoreDownstream)) {
     ignoreDownstream <- FALSE
 }
 
-peaks <- readPeakFile(peaks)
+if (!is.null(args$header)) {
+    header <- TRUE
+} else {
+    header <- FALSE
+}
+
+peaks <- readPeakFile(peaks, header=header)
 
 # Make TxDb from GTF
 txdb <- makeTxDbFromGFF(gtf, format="gtf")

--- a/tools/chipseeker/chipseeker.R
+++ b/tools/chipseeker/chipseeker.R
@@ -100,11 +100,14 @@ write.table(resout, file="out.tab", sep="\t", row.names=FALSE, quote=FALSE)
 if (!is.null(args$plots)) {
     pdf("out.pdf", width=14)
     plotAnnoPie(peakAnno)
-    plotAnnoBar(peakAnno)
+    p1 <- plotAnnoBar(peakAnno)
+    print(p1)
     vennpie(peakAnno)
     upsetplot(peakAnno)
-    plotDistToTSS(peakAnno, title="Distribution of transcription factor-binding loci\nrelative to TSS")
+    p2 <- plotDistToTSS(peakAnno, title="Distribution of transcription factor-binding loci\nrelative to TSS")
+    print(p2)
     dev.off()
+    rm(p1, p2)
 }
 
 ## Output RData file

--- a/tools/chipseeker/chipseeker.xml
+++ b/tools/chipseeker/chipseeker.xml
@@ -1,4 +1,4 @@
-<tool id="chipseeker" name="ChIPseeker" version="1.18.0">
+<tool id="chipseeker" name="ChIPseeker" version="1.18.0+galaxy1">
     <description>for ChIP peak annotation and visualization</description>
     <requirements>
         <requirement type="package" version="1.18.0">bioconductor-chipseeker</requirement>

--- a/tools/chipseeker/chipseeker.xml
+++ b/tools/chipseeker/chipseeker.xml
@@ -22,6 +22,7 @@ echo $(R --version | grep version | grep -v GNU)", ChIPseeker version" $(R --van
         Rscript '$__tool_directory__/chipseeker.R'
 
         -i '$peaks'
+        -H $header
         -G '$gtf'
         -u $adv.upstream
         -d $adv.downstream
@@ -51,6 +52,7 @@ echo $(R --version | grep version | grep -v GNU)", ChIPseeker version" $(R --van
     </command>
     <inputs>
         <param name="peaks" type="data" format="bed,interval,tabular" label="Peaks file" help="A peaks file in BED format." />
+        <param name="header" type="boolean" truevalue="True" falsevalue="False" checked="False" label="Peaks file has header?" help="If this option is set to Yes, the tool will assume that the peak file has column headers in the first row. Default: No" />
         <conditional name="gtf_source">
             <param name="gtf_source_select" type="select" label="Annotation source" help="Select a GTF to use for annotation source.">
                 <option value="cached" selected="true">Use a built-in GTF</option>
@@ -189,7 +191,7 @@ ChIPseeker also produces plots to help users visualise the overlaps in annotatio
 
 **Inputs**
 
-A peaks file in BED, Interval or Tabular format e.g from MACS2 or DiffBind.
+A peaks file in BED, Interval or Tabular format e.g from MACS2 or DiffBind. Note that there is an option to specify if the input peaks file has a header row. No header row is assumed by default, which is usually the case for BED format e.g. MACS narrowpeak, however other formats e.g. MACS tabular format, may contain a header row.
 
 Example:
 

--- a/tools/chipseeker/chipseeker.xml
+++ b/tools/chipseeker/chipseeker.xml
@@ -214,7 +214,7 @@ A GTF file for annotation. The GTF file must have fields called "gene_id" and ge
 This tool outputs
 
     * a file of annotated peaks in Interval or Tabular format
-    * a PDF of plots (plotAnnoPie, vennpie, upsetplot)
+    * a PDF of plots (plotAnnoPie, plotAnnoBar, vennpie, upsetplot, plotDistToTSS)
 
 Optionally, you can choose to output
 


### PR DESCRIPTION
- Found that chipseeker assumes a header is present in the input peaks file, unless the file has "bed" or related in the name (see here header https://github.com/GuangchuangYu/ChIPseeker/blob/master/R/readPeakFile.R#L60-L61), which was resulting in 1 peak/row of input not being output by this tool. So made an option for header, with default no header (assume most people would input BED)
- Fixed 2 plots that weren't being output in the PDF
- Fixed link to repo in shed.yml
