### PR TITLE
Bismark: fix element_identifier sanitizing

### DIFF
--- a/tools/bismark/bismark_bowtie2_wrapper.xml
+++ b/tools/bismark/bismark_bowtie2_wrapper.xml
@@ -1,4 +1,4 @@
-<tool id="bismark_bowtie2" name="Bismark Mapper" version="0.22.1+galaxy1" profile="18.01">
+<tool id="bismark_bowtie2" name="Bismark Mapper" version="0.22.1+galaxy2" profile="18.01">
     <description>Bisulfite reads mapper</description>
     <requirements>
         <requirement type="package" version="0.22.1">bismark</requirement>
@@ -16,29 +16,29 @@
             #else
                 #set read1 = 'input_1.fq'
             #end if
-            ln -s '${singlePaired.input_singles}' ${read1} &&
+            ln -s '${singlePaired.input_singles}' '${read1}' &&
         #else:
             #set $mate1 = list()
             #set $mate2 = list()
             #for $mate_pair in $singlePaired.mate_list
 
                 #if $mate_pair.input_mate1.ext == "fasta":
-                    #set read1 = re.sub('[^\s\w\-]', '_', str($mate_pair.input_mate1.element_identifier)) + '_1.fa'
+                    #set read1 = re.sub('[^\w\-_.]', '_', str($mate_pair.input_mate1.element_identifier)) + '_1.fa'
                 #elif $mate_pair.input_mate1.ext in ["fastq.gz", "fastqsanger.gz"]:
-                    #set read1 = re.sub('[^\s\w\-]', '_', str($mate_pair.input_mate1.element_identifier)) + '_1.fq.gz'
+                    #set read1 = re.sub('[^\w\-_.]', '_', str($mate_pair.input_mate1.element_identifier)) + '_1.fq.gz'
                 #else
-                    #set read1 = re.sub('[^\s\w\-]', '_', str($mate_pair.input_mate1.element_identifier)) + '_1.fq'
+                    #set read1 = re.sub('[^\w\-_.]', '_', str($mate_pair.input_mate1.element_identifier)) + '_1.fq'
                 #end if
-                ln -s '${mate_pair.input_mate1}' ${read1} &&
+                ln -s '${mate_pair.input_mate1}' '${read1}' &&
 
                 #if $mate_pair.input_mate2.ext == "fasta":
-                    #set read2 = re.sub('[^\s\w\-]', '_', str($mate_pair.input_mate1.element_identifier)) + '_2.fa'
+                    #set read2 = re.sub('[^\w\-_.]', '_', str($mate_pair.input_mate1.element_identifier)) + '_2.fa'
                 #elif $mate_pair.input_mate2.ext in ["fastq.gz", "fastqsanger.gz"]:
-                    #set read2 = re.sub('[^\s\w\-]', '_', str($mate_pair.input_mate1.element_identifier)) + '_2.fq.gz'
+                    #set read2 = re.sub('[^\w\-_.]', '_', str($mate_pair.input_mate1.element_identifier)) + '_2.fq.gz'
                 #else
-                    #set read2 = re.sub('[^\s\w\-]', '_', str($mate_pair.input_mate1.element_identifier)) + '_2.fq'
+                    #set read2 = re.sub('[^\w\-_.]', '_', str($mate_pair.input_mate1.element_identifier)) + '_2.fq'
                 #end if
-                ln -s '${mate_pair.input_mate2}' ${read2} &&
+                ln -s '${mate_pair.input_mate2}' '${read2}' &&
 
                 $mate1.append( str($read1) )
                 $mate2.append( str($read2) )


### PR DESCRIPTION
One last (:crossed_fingers:) PR to fix an issue with latest changes in bismark: errors when element_identifier contains spaces