### PR TITLE
Remove loss type parameter

### DIFF
--- a/tools/tool_recommendation_model/create_tool_recommendation_model.xml
+++ b/tools/tool_recommendation_model/create_tool_recommendation_model.xml
@@ -31,7 +31,6 @@
             --learning_rate '$nn_parameters.learning_rate'
             --activation_recurrent '$nn_parameters.activation_recurrent'
             --activation_output '$nn_parameters.activation_output'
-            --loss_type '$nn_parameters.loss_type'
             --output_model '$outfile_model'
 ]]>
     </command>
@@ -59,7 +58,6 @@
             <param name="learning_rate" type="text" value="0.0001,0.1" label="Learning rate" help="Provide a range of positive real numbers to sample the learning rate. Learning rate defines the speed of neural network learning. A higher value will ensure fast learning and smaller value will ensure slower learning. An example: 0.0001,0.1"/>
             <param name="activation_recurrent" type="text" value="elu" label="Name of the activation function for recurrent layers" help="It is a mathematical function that transforms the input of recurrent layers to the following neural network layer."/>
             <param name="activation_output" type="text" value="sigmoid" label="Name of the activation function for output layer" help="It is a mathematical function that transforms the input of the last dense layer to the output of the neural network."/>
-            <param name="loss_type" type="text" value="binary_crossentropy" label="Name of the loss function" help="The loss/error function computes an error between the true and predicted output. This error is minimised during neural network learning to be as close to the true output as possible. Root Mean Square Propagation (RMSProp) is used as an optimiser to minimise error computed by this error function."/>
         </section>
     </inputs>
     <outputs>
@@ -138,7 +136,6 @@ There are multiple parameters which can be set. They are divided into 3 categori
     - "learning_rate": The learning rate specifies the speed of learning. A higher value ensures fast learning (the optimiser may diverge) and a lower value causes slow learning (may not reach the optimum). This parameter should be optimised as well.
     - "activation_recurrent": Activations are mathematical functions to transform input into output. This takes the name of an activation function from the list of Keras activations (https://keras.io/activations/) for recurrent layers.
     - "activation_output": This takes the activation for transforming the input of the last layer to the output of the neural network. It is also taken from Keras activations (https://keras.io/activations/).
-    - "loss_type": This is also a mathematical function which computes the error between true and predicted outputs. An optimizer uses this loss function to compute error and minimize it. It is taken from the list of Keras optimisers (https://keras.io/optimizers/).
 
 -----
 

--- a/tools/tool_recommendation_model/main.py
+++ b/tools/tool_recommendation_model/main.py
@@ -112,7 +112,6 @@ if __name__ == "__main__":
     arg_parser.add_argument("-lr", "--learning_rate", required=True, help="learning rate")
     arg_parser.add_argument("-ar", "--activation_recurrent", required=True, help="activation function for recurrent layers")
     arg_parser.add_argument("-ao", "--activation_output", required=True, help="activation function for output layers")
-    arg_parser.add_argument("-lt", "--loss_type", required=True, help="type of the loss/error function")
     # get argument values
     args = vars(arg_parser.parse_args())
     tool_usage_path = args["tool_usage_file"]
@@ -134,7 +133,6 @@ if __name__ == "__main__":
     learning_rate = args["learning_rate"]
     activation_recurrent = args["activation_recurrent"]
     activation_output = args["activation_output"]
-    loss_type = args["loss_type"]
 
     config = {
         'cutoff_date': cutoff_date,
@@ -152,8 +150,7 @@ if __name__ == "__main__":
         'recurrent_dropout': recurrent_dropout,
         'learning_rate': learning_rate,
         'activation_recurrent': activation_recurrent,
-        'activation_output': activation_output,
-        'loss_type': loss_type
+        'activation_output': activation_output
     }
 
     # Extract and process workflows


### PR DESCRIPTION
The loss input parameter was not needed as it is used in a derived form (weighted loss) and it is not required for users to change this error function