### PR TITLE
Bismark: fix ceil returning a float in python2.7

### DIFF
--- a/tools/bismark/bismark_wrapper.py
+++ b/tools/bismark/bismark_wrapper.py
@@ -167,7 +167,7 @@ def __main__():
     # alignment options
     if args.num_threads > 2:
         # divide num_threads by 2 here since bismark will spawn 2 jobs with -p threads each
-        cmd.extend(['-p', str(math.ceil(args.num_threads / 2))])
+        cmd.extend(['-p', str(int(math.ceil(args.num_threads / 2)))])
     if args.seed_mismatches:
         cmd.extend(['-N', str(args.seed_mismatches)])
     if args.seed_len:


### PR DESCRIPTION
A little bug fix for bismark: we got an error with bismark because python 2.7's math.ceil returns a float instead of int, producing an invalid bismark command.
I don't know why I didn't see it in earlier jobs, but so easy to fix anyway...