### PR TITLE
fix problem with score filters not being applied

### DIFF
--- a/chemicaltoolbox/rdock/rbdock.xml
+++ b/chemicaltoolbox/rdock/rbdock.xml
@@ -15,10 +15,10 @@ ln -s $receptor_prm receptor.prm &&
 #end if
 rbdock -i ligands.sdf -r receptor.prm -p dock.prm -n $num -o output &&
 sdsort -n -s -fSCORE output.sd |
-#if $score and $score > 0:
+#if $score:
   sdfilter -f'\$SCORE <= $score' |
 #end if
-#if $nscore and $nscore > 0:
+#if $nscore:
   sdfilter -f'\$SCORE.norm <= $nscore' |
 #end if
 sdfilter -f'\$_COUNT <= $top' > '$output'

--- a/chemicaltoolbox/rdock/rbdock.xml
+++ b/chemicaltoolbox/rdock/rbdock.xml
@@ -1,4 +1,4 @@
-<tool id="rdock_rbdock" name="rDock docking" version="0.1">
+<tool id="rdock_rbdock" name="rDock docking" version="0.1.1">
     <description>- perform protein-ligand docking with rDock</description>
     <macros>
         <import>rdock_macros.xml</import>


### PR DESCRIPTION
The `$score > 0` bits were stopping the score filter being applied when the value was negative. 