### PR TITLE
aggressive detect_errors was too aggressive

### DIFF
--- a/chemicaltoolbox/sucos/sucos.xml
+++ b/chemicaltoolbox/sucos/sucos.xml
@@ -1,10 +1,10 @@
-<tool id="sucos_docking_scoring" name="Score docked poses using SuCOS" version="0.1">
+<tool id="sucos_docking_scoring" name="Score docked poses using SuCOS" version="0.1.1">
     <description>- compare shape and feature overlap of docked ligand poses to a reference molecule</description>
     <macros>
         <import>sucos_macros.xml</import>
     </macros>
     <expand macro="requirements"/>
-    <command detect_errors="aggressive"><![CDATA[
+    <command detect_errors="exit_code"><![CDATA[
         python '$__tool_directory__/sucos.py'
             -i '$input'
             -r '$refmol'

--- a/chemicaltoolbox/sucos/sucos_cluster.xml
+++ b/chemicaltoolbox/sucos/sucos_cluster.xml
@@ -1,4 +1,4 @@
-<tool id="sucos_clustering" name="Cluster ligands using SuCOS" version="0.1">
+<tool id="sucos_clustering" name="Cluster ligands using SuCOS" version="0.1.1">
     <description>based on the overlap of 3D features</description>
     <macros>
         <import>sucos_macros.xml</import>
@@ -6,7 +6,7 @@
     <expand macro="requirements">
         <requirement type="package" version="1.3.0">scipy</requirement>
     </expand>
-    <command detect_errors="aggressive"><![CDATA[
+    <command detect_errors="exit_code"><![CDATA[
         python '$__tool_directory__/sucos_cluster.py'
             -i '$input'
             -t $threshold

--- a/chemicaltoolbox/sucos/sucos_max.xml
+++ b/chemicaltoolbox/sucos/sucos_max.xml
@@ -1,10 +1,10 @@
-<tool id="sucos_max_score" name="Max SuCOS score" version="0.1">
+<tool id="sucos_max_score" name="Max SuCOS score" version="0.1.1">
     <description>- determine maximum SuCOS score of ligands against clustered fragment hits</description>
     <macros>
         <import>sucos_macros.xml</import>
     </macros>
     <expand macro="requirements"/>
-    <command detect_errors="aggressive"><![CDATA[
+    <command detect_errors="exit_code"><![CDATA[
         python '$__tool_directory__/sucos_max.py'
             -i '$input'
             -o '$output'


### PR DESCRIPTION
I changed the detect_errors property to `exit_code` as when RDKit encounters a bad molecule it writes out ERROR to stderr, but this does not stop the tool from working (that molecule is skipped) and the tool completes successfully with exit code of 0.

Not sure it there is a mechanism to give user feedback that some records were not processed?