### PR TITLE
Update ribotaper_part2_create_metaplots.xml

### DIFF
--- a/tools/rna_tools/ribotaper/ribotaper_part2_create_metaplots.xml
+++ b/tools/rna_tools/ribotaper/ribotaper_part2_create_metaplots.xml
@@ -1,6 +1,7 @@
 <tool id="ribotaper_create_metaplots" name="ribotaper part 2: metagene analysis for P-sites definition" version="0.1.0">
     <requirements>
             <requirement type="package" version="1.3.1a">ribotaper</requirement>
+            <requirement type="package" version="9.22">ghostscript</requirement>
     </requirements>
     <stdio>
         <exit_code range="1:" />


### PR DESCRIPTION
ghostscript is required for the collation of those pdfs - it's not available in the root in newer galaxy versions