### PR TITLE
Alevin fixes for frequency and raw frequency output

### DIFF
--- a/tools/salmon/alevin.xml
+++ b/tools/salmon/alevin.xml
@@ -1,4 +1,4 @@
-<tool id="alevin" name="Alevin" version="@VERSION@">
+<tool id="alevin" name="Alevin" version="@VERSION@+galaxy1">
     <description>Quantification and analysis of 3’ tagged-end single-cell sequencing data</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/salmon/alevin.xml
+++ b/tools/salmon/alevin.xml
@@ -91,6 +91,9 @@
         #if $optional.maxNumBarcodes:
             --maxNumBarcodes '${optional.maxNumBarcodes}'
         #end if
+        #if $optional.freqThreshold:
+            --freqThreshold '${optional.freqThreshold}'
+        #end if
 
         #if $optional.dumpMtx != "--dumpMtx":
             && python '$__tool_directory__/vpolo_convert.py' -m
@@ -145,6 +148,7 @@
             <param name="keepCBFraction" type="float" optional="true" help="Fraction of cellular barcodes to keep (Between 0 and 1)."/>
             <param name="lowRegionMinNumBarcodes" type="integer" optional="true" help="Minimum number of cell barcodes to use fo learning low confidence region (defaults to 200)"/>
             <param name="maxNumBarcodes" type="integer" optional="true" help="Maximum allowable limit to process the cell barcodes. Defaults to 100000"/>
+            <param name="freqThreshold" type="integer" optional="true" help="Minimum frequency for a barcode to be considered. Defaults to 10"/>
         </section>
     </inputs>
     <outputs>
@@ -153,6 +157,9 @@
         </data>
         <data name="quants_mat.mtx.gz" label="quants_mat.mtx.gz" format="mtx" from_work_dir="output/alevin/quants_mat.mtx.gz">
             <filter>optional["dumpMtx"]</filter>
+        </data>
+        <data name="raw_cb_frequency.txt" label="raw_cb_frequency.txt" format="txt" from_work_dir="output/alevin/raw_cb_frequency.txt">
+            <filter>optional["dumpFeatures"]</filter>
         </data>
         <data name="quants_mat_cols.txt" label="quants_mat_cols.txt" format="txt" from_work_dir="output/alevin/quants_mat_cols.txt"/>
         <data name="quants_mat_rows.txt" label="quants_mat_rows.txt" format="txt" from_work_dir="output/alevin/quants_mat_rows.txt"/>
@@ -196,7 +203,7 @@
         </collection>
     </outputs>
     <tests>
-        <test expect_num_outputs="10">
+        <test expect_num_outputs="11">
             <conditional name="refTranscriptSource">
                 <param name="TranscriptSource" value="history"/>
                 <section name="s_index">
@@ -213,6 +220,9 @@
             <param name="protocol" value="--chromium"/>
             <param name="tgmap" value="minitxp.tsv"/>
             <param name="dumpMtx" value="Yes"/>
+            <param name="freqThreshold" value="5"/>
+            <param name="dumpFeatures" value="Yes"/>
+            <param name="keepCBFraction" value="1"/>
             <output name="quants_mat.mtx.gz" file="alevin_mat.mtx.gz" ftype="mtx" compare="sim_size"/>
         </test>
     </tests>


### PR DESCRIPTION
This PR makes a couple of tweaks to the Alevin wrapper's behaviour:

 - Adds use of the undocumented 'freqThreshold' parameter, which has nevertheless been indicated to me a couple of times by the Alevin authors and is useful for our workflows.
 - Adds the 'raw_cb_frequency.txt' output, which is what is triggered by supplying --dumpFeatures. 