### PR TITLE
Update easy_join "Join two files"

### DIFF
--- a/tools/text_processing/text_processing/easyjoin.xml
+++ b/tools/text_processing/text_processing/easyjoin.xml
@@ -29,7 +29,7 @@
         <param name="infile1" format="tabular" type="data" label="1st file" />
         <param name="column1" label="Column to use from 1st file" type="data_column" data_ref="infile1" accept_default="true" />
 
-        <param name="infile2" format="txt" type="data" label="2nd File" />
+        <param name="infile2" format="tabular" type="data" label="2nd File" />
         <param name="column2" label="Column to use from 2nd file" type="data_column" data_ref="infile2" accept_default="true" />
 
         <param name="jointype" type="select" label="Output lines appearing in">


### PR DESCRIPTION
Update to accept only tabular on the second file as well. With just accepting txt, there is no dropdown to select a column. Which is inconsistent as the first file does have this dropdown.