### PR TITLE
add the most important PDB output

### DIFF
--- a/chemicaltoolbox/fpocket/fpocket.xml
+++ b/chemicaltoolbox/fpocket/fpocket.xml
@@ -49,7 +49,8 @@
         <param name="outputs" type="select" display="checkboxes" multiple="true" label="Output files">
             <option value="atoms" selected="true">PDB files containing the atoms in contact with each pocket</option>
             <option value="pock_verts">PQR files containing Voronoi vertices of each pocket</option>
-            <option value="all_verts">PQR file containing all Voronoi vertices found</option>
+            <option value="alpha_pdb" selected="true">PDB file containing alpha spheres found</option>
+            <option value="all_verts" selected="true">PQR file containing all Voronoi vertices found</option>
             <option value="info" selected="true">Log file containing pocket properties</option>
         </param>
     </inputs>
@@ -65,6 +66,9 @@
         </collection>
         <data format="pqr" name="all_verts_output" label="All Voronoi vertices found" from_work_dir="input_out/input_pockets.pqr">
             <filter>"all_verts" in outputs</filter>
+        </data>
+        <data format="pdb" name="alpha_pdb_output" label="PDB output with alpha spheres" from_work_dir="input_out/input_out.pdb">
+            <filter>"alpha_pdb" in outputs</filter>
         </data>
         <data format="txt" name="info_output" label="Pocket properties" from_work_dir="input_out/input_info.txt">
             <filter>"info" in outputs</filter>
@@ -95,6 +99,12 @@
                 <element name="pocket1" ftype="pdb" file="pocket1_atm.pdb" lines_diff="2"/>
             </output_collection>
             <output name="info_output" ftype="txt" file='2brc_info.txt' lines_diff="20"/>
+            <output name="alpha_pdb_output" ftype="pdb">
+              <assert_contents>
+                <has_text text="ATOM      1    N MET A   1"/>
+                <has_text text="HETATM    6 APOL STP C   "/>
+              </assert_contents>
+            </output>
         </test>
     </tests>
     <help><![CDATA[

--- a/chemicaltoolbox/fpocket/fpocket.xml
+++ b/chemicaltoolbox/fpocket/fpocket.xml
@@ -1,4 +1,4 @@
-<tool id="fpocket" name="fpocket" version="0.1.0">
+<tool id="fpocket" name="fpocket" version="3.1.3">
     <description>- find potential binding sites in protein structures</description>
     <requirements>
         <requirement type="package" version="3.1.3">fpocket</requirement>


### PR DESCRIPTION
Hi @bgruening !

I've modified fpocket. The PDB file *_out.pdb is the most important output (see page 31 of the fpocket manual to confirm - https://github.com/Discngine/fpocket/blob/master/doc/manual_fpocket2.pdf)
I've included this output and made sure that this and the all_verts output are selected by default. 
These two outputs are needed for visualisation of pockets and are used by the pymol and VMD visualisation scripts that are usually used with fpocket. 
Note that the PDB collection (atoms_output) does not contain the same information as found in *_out.pdb. This file is unique and important :smiley: Also updated the testcase.


All the best,
Chris

