### PR TITLE
transfs with multiple models

### DIFF
--- a/chemicaltoolbox/xchem-deep/transfs.py
+++ b/chemicaltoolbox/xchem-deep/transfs.py
@@ -210,14 +210,14 @@ def generate_predictions_filename(work_dir, predict_file_name):
     return "{0}{1}{2}".format(work_dir, os.path.sep, predict_file_name)
 
 
-def run_predictions():
+def run_predictions(model):
     global types_file_name
     global predict_file_name
     global work_dir
     # python3 scripts/predict.py -m resources/dense.prototxt -w resources/weights.caffemodel -i work_0/test_set.types >> work_0/caffe_output/predictions.txt
     cmd1 = ['python3', '/train/fragalysis_test_files/scripts/predict.py',
             '-m', '/train/fragalysis_test_files/resources/dense.prototxt',
-            '-w', '/train/fragalysis_test_files/resources/weights.caffemodel',
+            '-w', os.path.sep.join(['/train/fragalysis_test_files/resources', model]),
             '-i', os.path.sep.join([work_dir, types_file_name]),
             '-o', os.path.sep.join([work_dir, predict_file_name])]
     log("CMD:", cmd1)
@@ -286,13 +286,13 @@ def patch_scores_sdf(outfile, scores):
     sdf_file.close()
 
 
-def execute(ligands_sdf, protein, outfile, distance, mock=False):
+def execute(ligands_sdf, protein, outfile, distance, model='weights.caffemodel', mock=False):
 
     write_inputs(protein, ligands_sdf, distance)
     if mock:
         mock_predictions()
     else:
-        run_predictions()
+        run_predictions(model)
     scores = read_predictions()
     patch_scores_sdf(outfile, scores)
 
@@ -307,6 +307,7 @@ def main():
     parser.add_argument('-d', '--distance', type=float, default=2.0, help="Cuttoff for removing waters")
     parser.add_argument('-o', '--outfile', default='output.sdf', help="File name for results")
     parser.add_argument('-w', '--work-dir', default=".", help="Working directory")
+    parser.add_argument('-m', '--model', default="weights.caffemodel", help="Model to use for predictions")
     parser.add_argument('--mock', action='store_true', help='Generate mock scores rather than run on GPU')
 
     args = parser.parse_args()
@@ -314,7 +315,7 @@ def main():
 
     work_dir = args.work_dir
 
-    execute(args.input, args.receptor, args.outfile, args.distance, mock=args.mock)
+    execute(args.input, args.receptor, args.outfile, args.distance, model=args.model, mock=args.mock)
 
 
 if __name__ == "__main__":

--- a/chemicaltoolbox/xchem-deep/transfs.xml
+++ b/chemicaltoolbox/xchem-deep/transfs.xml
@@ -1,11 +1,11 @@
-<tool id="xchem_transfs_scoring" name="XChem TransFS pose scoring" version="0.2.0">
+<tool id="xchem_transfs_scoring" name="XChem TransFS pose scoring" version="0.3.0">
     <description>using deep learning</description>
 
     <requirements>
         <!--requirement type="package" version="3.0.0">openbabel</requirement-->
         <!--requirement type="package" version="3.7">python</requirement-->
         <!-- many other requirements are needed -->
-        <container type="docker">informaticsmatters/deep-app-ubuntu-1604:0.9</container>
+        <container type="docker">informaticsmatters/deep-app-ubuntu-1604:1.2</container>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
 
@@ -24,7 +24,7 @@
 
     ## mkdir -p ligands &&
     cd ../ &&
-    python '$__tool_directory__/transfs.py' -i ./workdir/ligands.sdf -r ./workdir/receptor.pdb -d $distance -w /train/fragalysis_test_files/workdir &&
+    python '$__tool_directory__/transfs.py' -i ./workdir/ligands.sdf -r ./workdir/receptor.pdb -d $distance -w /train/fragalysis_test_files/workdir --model '$model' &&
     ls -l &&
     ls -l workdir &&
     sudo -u ubuntu cp ./workdir/output.sdf '$output' &&
@@ -44,6 +44,12 @@
         <param type="data" name="receptor" format="pdb" label="Receptor" help="Select a receptor (pdb format)."/>
         <param type="data" name="ligands" format="sdf,mol" label="Ligands" help="Ligands (docked poses) in SDF format)"/>
         <param name="distance" type="float" value="2.0" min="1.0" max="5.0" label="Distance to waters" help="Remove waters closer than this distance to any ligand heavy atom"/>
+        <param name="model" type="select" label="Model for predictions">
+            <option value="weights.caffemodel">No threshold (original model)</option>
+            <option value="10nm.0_iter_50000.caffemodel">10nM threshold</option>
+            <option value="50nm.0_iter_50000.caffemodel">50nM threshold</option>
+            <option value="200nm.0_iter_50000.caffemodel">200nM threshold</option>
+        </param>
         <param type="hidden" name="mock" value="" label="Mock calculations" help="Use random numbers instead of running on GPU"/>
     </inputs>
     <outputs>


### PR DESCRIPTION
@bgruening Here is an initial attempt at an updated transfs tool.
The key change is that the user can choose from a number of models to use for the predictions.
Those models are present as files in the container in `/train/fragalysis_test_files/resources`.
There are 4 in total to choose from.

This obviously needs a new container image (`informaticsmatters/deep-app-ubuntu-1604:1.2`) that is a bit different from the one currently being used. The relevant files were moved from `/root/train/fragalysis_test_files` to `/train/fragalysis_test_files` and permissions on the files/dirs changed so that a normal user can run things. This means that most of your hacks to get round the original permissions problems won't be needed now, but I've not changed anything related to that, and I'm obviously not able to test anything at this stage.

So this PR is a long way off being able to merge, but hopefully it's an early heads up on what is needed.  