### PR TITLE
add metadata tags field1...6 to group category

### DIFF
--- a/tools/cellprofiler/common.xml
+++ b/tools/cellprofiler/common.xml
@@ -385,6 +385,12 @@ f.close()
                         <option value="ImageId">ImageId</option>
                         <option value="Screen">Screen</option>
                         <option value="Series">Series</option>
+                        <option value="field1">field1</option>
+                        <option value="field2">field2</option>
+                        <option value="field3">field3</option>
+                        <option value="field4">field4</option>
+                        <option value="field5">field5</option>
+                        <option value="field6">field6</option>
                     </param>
                 </when>
                 <when value="No">


### PR DESCRIPTION
because regex for file name was changed to 'field1....field6', these are cellprofiler metadata tags and must be made available for selection in the 'group category' parameter within "Group" section of common.xml
