### PR TITLE
Easyjoin: we can change the temporary directory

### DIFF
--- a/tools/text_processing/text_processing/easyjoin
+++ b/tools/text_processing/text_processing/easyjoin
@@ -20,7 +20,7 @@ sub cleanup_files(@);
 
 
 my $PROGRAM="easyjoin";
-my $VERSION="0.6.1";
+my $VERSION="0.6.2";
 
 my $debug=undef;
 my $HEADER=undef;
@@ -41,8 +41,18 @@ my $input_filename2;
 ##
 $ENV{'LANG'}="C";## "C" locale is critical for sorting and joining correctly
 parse_commandline_options();
-my (undef, $tmp_filename1) = tempfile(OPEN=>0);
-my (undef, $tmp_filename2) = tempfile(OPEN=>0);
+my ($tmp_filename1, $tmp_filename2);
+# if GNU sort's --temporary-directory option is used,
+#  write the result as well in this dir!
+if (defined $SORT_TEMP_DIR) {
+	(undef, $tmp_filename1) = tempfile(OPEN=>0, DIR => $SORT_TEMP_DIR);
+	(undef, $tmp_filename2) = tempfile(OPEN=>0, DIR => $SORT_TEMP_DIR);
+}
+else {
+	(undef, $tmp_filename1) = tempfile(OPEN=>0);
+	(undef, $tmp_filename2) = tempfile(OPEN=>0);
+}
+
 sort_file($input_filename1, $tmp_filename1, $FILE1_KEY_COLUMN);
 sort_file($input_filename2, $tmp_filename2, $FILE2_KEY_COLUMN);
 my $join_exit_code = join_files($tmp_filename1, $tmp_filename2);

--- a/tools/text_processing/text_processing/easyjoin.xml
+++ b/tools/text_processing/text_processing/easyjoin.xml
@@ -1,4 +1,4 @@
-<tool id="tp_easyjoin_tool" name="Join" version="@BASE_VERSION@.2">
+<tool id="tp_easyjoin_tool" name="Join" version="@BASE_VERSION@.3">
     <description>two files</description>
     <macros>
         <import>macros.xml</import>
@@ -13,6 +13,7 @@
         chmod +x sort-header &&
         perl $__tool_directory__/easyjoin
             $jointype
+            -T '$temporary_directory'
             -t $'\t'
             $header
             -e '$empty_string_filler'
@@ -53,6 +54,7 @@
                 </valid>
             </sanitizer>
         </param>
+        <param name="temporary_directory" type="text" value="/tmp" label="GNU sort's --temporary-directory option (can be changed to avoid 'No space left on device' error)."/>
     </inputs>
     <outputs>
         <data name="output" format_source="infile1" metadata_source="infile1"/>
@@ -65,6 +67,7 @@
             <param name="column2" value="1" />
             <param name="header" value="True" />
             <param name="jointype" value="-a 1 -a 2" />
+            <param name="temporary_directory" value="/tmp" />
             <output name="output" file="easyjoin_result1.tabular" />
         </test>
     </tests>


### PR DESCRIPTION
We can set the --temporary-directory option for sort in XML. And the perl script will write also the result file in this directory.
It is useful for large files that don't fit in /tmp: `/tmp/sortA3aLjF: No space left on device`