### PR TITLE
Change name of cut tool to avoid confusion with built-in cut tool

### DIFF
--- a/tools/text_processing/text_processing/cut.xml
+++ b/tools/text_processing/text_processing/cut.xml
@@ -1,4 +1,4 @@
-<tool id="tp_cut_tool" name="Cut" version="@BASE_VERSION@.0">
+<tool id="tp_cut_tool" name="Advanced Cut" version="@BASE_VERSION@.0">
     <description>columns from a table (cut)</description>
     <macros>
         <import>macros.xml</import>


### PR DESCRIPTION
I have been getting a lot of reports from people getting stuck in tutorials because they are using this cut tool instead of the built-in one. 

![image](https://user-images.githubusercontent.com/2563865/80475191-cdb40880-8948-11ea-92dc-948b814e86b0.png)

Maybe renaming this tool would avoid confusion about which to use?

The problem arises because this tool does not rearrange columns if you specify e.g. "c2,c5,c3", but keeps them in order. In the ATAC-Seq tutorial for instance, this leads to an invalid BED file. (we could also update this tool to do the column rearranging like the other cut tool) 