### PR TITLE
Fix frankenstein ligand tool

### DIFF
--- a/chemicaltoolbox/rdock/select_points_SDF.py
+++ b/chemicaltoolbox/rdock/select_points_SDF.py
@@ -55,7 +55,7 @@ def select_points(all_coordinates):
 
 def sdfout(centers, writer):
     n = len(centers)
-    writer.write("Frankenstein_ligand\nGalaxy select_points_sdf tool\n\n")
+    writer.write("Frankenstein ligand\n00000000000000000000 3D\nCreated in Galaxy\n")
     writer.write("%3d  0  0  0  0  0  0  0  0  0999 V2000\n" % n)
     for record in centers:
         x, y, z = record

--- a/chemicaltoolbox/rdock/select_points_SDF.xml
+++ b/chemicaltoolbox/rdock/select_points_SDF.xml
@@ -1,4 +1,4 @@
-<tool id="ctb_frankenstein_ligand" name="Create Frankenstein ligand" version="0.1.0">
+<tool id="ctb_frankenstein_ligand" name="Create Frankenstein ligand" version="0.1.1">
     <description>for docking active site definition</description>
     <requirements>
         <requirement type="package" version="3.7">python</requirement>

--- a/chemicaltoolbox/rdock/test-data/select_points_output.sdf
+++ b/chemicaltoolbox/rdock/test-data/select_points_output.sdf
@@ -1,6 +1,6 @@
-Frankenstein_ligand
-Galaxy select_points_sdf tool
-
+Frankenstein ligand
+00000000000000000000 3D
+Created in Galaxy
  43  0  0  0  0  0  0  0  0  0999 V2000
     9.8790   -5.4960   26.1730 C   0  0  0  0  0  0  0  0  0  0  0  0
     7.1910   -5.0190   26.2290 C   0  0  0  0  0  0  0  0  0  0  0  0

--- a/chemicaltoolbox/rdock/test-data/select_points_output_v3000.sdf
+++ b/chemicaltoolbox/rdock/test-data/select_points_output_v3000.sdf
@@ -1,6 +1,6 @@
-Frankenstein_ligand
-Galaxy select_points_sdf tool
-
+Frankenstein ligand
+00000000000000000000 3D
+Created in Galaxy
  43  0  0  0  0  0  0  0  0  0999 V2000
     9.8790   -5.4960   26.1730 C   0  0  0  0  0  0  0  0  0  0  0  0
     7.1910   -5.0190   26.2290 C   0  0  0  0  0  0  0  0  0  0  0  0


### PR DESCRIPTION
This tool is meant to be used together with the rbcavity tool and it seems rbcavity is incredibly fussy about the formatting of the SD file and won't accept the files with the header that this tool was producing. :'(