### PR TITLE
Nanopolish 0.11.3

### DIFF
--- a/tools/nanopolish/macros.xml
+++ b/tools/nanopolish/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@VERSION@">0.13.2</token>
+    <token name="@VERSION@">0.11.3</token>
     <xml name="requirements">
         <requirements>
         <requirement type="package" version="@VERSION@">nanopolish</requirement>


### PR DESCRIPTION
The version 0.11.3 is currently the latest version with proper multiprocessing support for Conda. Therefore, I would think it make sense to offer the wrapper for that version, beside the latest 0.13.x.