### PR TITLE
[awk] Using right awk in biocontainers

### DIFF
--- a/tools/text_processing/text_processing/awk.xml
+++ b/tools/text_processing/text_processing/awk.xml
@@ -1,4 +1,4 @@
-<tool id="tp_awk_tool" name="Text reformatting" version="@BASE_VERSION@.1">
+<tool id="tp_awk_tool" name="Text reformatting" version="@BASE_VERSION@.2">
     <description>with awk</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/text_processing/text_processing/awk.xml
+++ b/tools/text_processing/text_processing/awk.xml
@@ -9,8 +9,9 @@
     <version_command>awk --version | head -n 1</version_command>
     <command>
 <![CDATA[
-        noargs=$(awk 'BEGIN{for(v in ENVIRON) {if (v!="PATH") printf "-u %s ",v}}') env $noargs
-        awk
+        whichawk=$(which awk)
+        env -i
+        $whichawk
             --sandbox
             -v FS='	'
             -v OFS='	'

--- a/tools/text_processing/text_processing/awk.xml
+++ b/tools/text_processing/text_processing/awk.xml
@@ -9,7 +9,7 @@
     <version_command>awk --version | head -n 1</version_command>
     <command>
 <![CDATA[
-        env -i
+        noargs=$(awk 'BEGIN{for(v in ENVIRON) {if (v!="PATH") printf "-u %s ",v}}') env $noargs
         awk
             --sandbox
             -v FS='	'

--- a/tools/text_processing/text_processing/awk.xml
+++ b/tools/text_processing/text_processing/awk.xml
@@ -9,9 +9,8 @@
     <version_command>awk --version | head -n 1</version_command>
     <command>
 <![CDATA[
-        whichawk=$(which awk)
         env -i
-        $whichawk
+        \$(which awk)
             --sandbox
             -v FS='	'
             -v OFS='	'


### PR DESCRIPTION
This commit: https://github.com/bgruening/galaxytools/commit/7bfc12bbe0f36602125eddde0e3b162ebe3345bf makes the corresponding biocontainer fall over with the kubernetes runner cause it uses Busybox's `awk` instead of `gawk`.

```
(base) BIOL-JT-ALEX:~ alex$ docker run -it --rm quay.io/biocontainers/gawk:4.2.0 'bash'
bash-4.2# env -i awk --help
BusyBox v1.22.1 (2014-05-23 01:24:27 UTC) multi-call binary.
Usage: awk [OPTIONS] [AWK_PROGRAM] [FILE]...
    -v VAR=VAL    Set variable
    -F SEP        Use SEP as field separator
    -f FILE        Read program from FILE
    -e AWK_PROGRAM

bash-4.2# awk --help
Usage: awk [POSIX or GNU style options] -f progfile [--] file ...
Usage: awk [POSIX or GNU style options] [--] 'program' file ...
POSIX options:        GNU long options: (standard)
    -f progfile        --file=progfile
    -F fs            --field-separator=fs
    -v var=val        --assign=var=val
[...]
gawk is a pattern scanning and processing language.
By default it reads standard input and writes standard output.
Examples:
    gawk '{ sum += $1 }; END { print sum }' file
    gawk -F: '{ print $1 }' /etc/passwd
```

```
bash-4.2# which awk
/usr/local/bin/awk
bash-4.2# env -i which awk
/usr/bin/awk
```


Tool fails with
```
awk: unrecognized option '--sandbox'
BusyBox v1.22.1 (2014-05-23 01:24:27 UTC) multi-call binary.

Usage: awk [OPTIONS]
etc...
```

