### PR TITLE
[tp_sort_rows] print py2->py3

### DIFF
--- a/tools/text_processing/text_processing/sort_rows.xml
+++ b/tools/text_processing/text_processing/sort_rows.xml
@@ -1,4 +1,4 @@
-<tool id="tp_sort_rows" name="Sort a row" version="@BASE_VERSION@.0">
+<tool id="tp_sort_rows" name="Sort a row" version="@BASE_VERSION@.0+galaxy0">
     <description>according to their columns</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/text_processing/text_processing/sort_rows.xml
+++ b/tools/text_processing/text_processing/sort_rows.xml
@@ -5,7 +5,7 @@
     </macros>
     <command>
 <![CDATA[
-    python -c 'for line in ( "\t".join(sorted(line.strip().split("\t"))) for line in open("$infile") ): print line' > $outfile
+    python -c 'for line in ( "\t".join(sorted(line.strip().split("\t"))) for line in open("$infile") ): print(line)' > $outfile
 ]]>
     </command>
     <inputs>


### PR DESCRIPTION
Containerized tool test was failing due to the old print. This makes it work. Alternative is to set py2 hard requirement potentially, but this print should be compatible with 2 and 3.
(This could be considered a paper-cut, but I can't set the label in this repo)