### PR TITLE
adding fastq.gz to flye ext parser

### DIFF
--- a/tools/flye/flye.xml
+++ b/tools/flye/flye.xml
@@ -1,4 +1,4 @@
-<tool id="flye" name="Flye assembly" version="2.6">
+<tool id="flye" name="Flye assembly" version="2.6+galaxy0">
     <description>of long and error-prone reads</description>
     <macros>
         <import>macros.xml</import>
@@ -12,7 +12,7 @@
 
         #if $input.is_of_type('fastqsanger', 'fastq'):
             #set $ext = 'fastq'
-        #elif $input.is_of_type('fastqsanger.gz'):
+        #elif $input.is_of_type('fastqsanger.gz', 'fastq.gz'):
             #set $ext = 'fastq.gz'
         #elif $input.is_of_type('fasta.gz'):
             #set $ext = 'fasta.gz'


### PR DESCRIPTION
Current version of flye doesn't work on fastq.gz files because it doesn't set the extension, this should fix that.