### PR TITLE
Salmon wrapper fixes

### DIFF
--- a/tools/salmon/macros.xml
+++ b/tools/salmon/macros.xml
@@ -140,7 +140,7 @@
         help="[Experimental]: The fraction of the read that must be covered by MMPs (of length >= 31) if this read is to be considered as 'mapped'. This may help to avoid 'spurious' mappings. A value of 0 (the default) denotes no coverage threshold (a single 31-mer can yield a mapping). Since coverage by exact matching, large, MMPs is a rather strict condition, this value should likely be set to something low, if used."/>
     </xml>
     <xml name="align">
-        <param name="afile" type="data" format="bam" label="Alignment file"/>
+        <param name="afile" type="data" format="qname_sorted.bam,unsorted.bam" label="Alignment file"/>
         <param name="transcript" type="data" format="fasta,fa" label="Transcript file"/>
         <expand macro="stranded"/>
         <param name="discardOrphans" type="boolean" truevalue="--discardOrphans" falsevalue="" checked="False"

--- a/tools/salmon/macros.xml
+++ b/tools/salmon/macros.xml
@@ -251,7 +251,7 @@
             <param name="sigDigits" type="integer" value="3"
             label="Significant Digits"
             help="The number of significant digits to write when outputting the EffectiveLength and NumReads columns."/>
-            <param name="vbPrior" type="float" value="1.0000000000000001e-05" optional="True"
+            <param name="vbPrior" type="float" value="0.01" optional="True"
             label="The prior that will be used in the VBEM algorithm."
             help="This is interpreted as a per-nucleotide prior, unless the --perTranscriptPrior flag is also given, in which case this is used as a transcript-level prior." />
             <param name="writeOrphanLinks" type="boolean" truevalue="--writeOrphanLinks" falsevalue="" checked="False" label="Write orphan links"


### PR DESCRIPTION
Salmon requires bam input in alignment mode to be randomly sorted, but accepting type "bam" causes Galaxy to coordinate-sort bams. This PR changes alignment-mode bam input to either "qname_sorted.bam" or "unsorted.bam" and avoids this sorting.

This also sets the default vbPrior parameter to Salmon's default, as the previous default in the wrapper was causing Salmon to fail when run with a small number of reads.