### PR TITLE
Update flye to 2.8.2

### DIFF
--- a/tools/flye/flye.xml
+++ b/tools/flye/flye.xml
@@ -84,7 +84,6 @@
         <test>
             <param name="inputs" ftype="fasta" value="nanopore.fasta"/>
             <param name="mode" value="--pacbio-raw"/>
-            <param name="g" value="10000"/>
             <output name="assembly_info" file="result1_assembly_info.txt" ftype="tabular" compare="sim_size"/>
             <output name="assembly_graph" file="result1_assembly_graph.dot" ftype="graph_dot" compare="sim_size"/>
             <output name="assembly_gfa" file="result1_assembly_graph.gfa" ftype="txt" compare="sim_size"/>
@@ -93,7 +92,6 @@
         <test>
             <param name="inputs" ftype="fasta" value="nanopore.fasta"/>
             <param name="mode" value="--nano-raw"/>
-            <param name="g" value="10000"/>
             <output name="assembly_info" file="result2_assembly_info.txt" ftype="tabular" compare="sim_size"/>
             <output name="assembly_graph" file="result2_assembly_graph.dot" ftype="graph_dot" compare="sim_size"/>
             <output name="assembly_gfa" file="result2_assembly_graph.gfa" ftype="txt" compare="sim_size"/>
@@ -102,9 +100,10 @@
         <test>
             <param name="inputs" ftype="fasta" value="nanopore.fasta"/>
             <param name="mode" value="--nano-corr"/>
-            <param name="g" value="10000"/>
             <param name="i" value="2"/>
-            <param name="asm" value="40"/>
+            <param name="asm|asm_select" value="true" />
+            <param name="asm|asm" value="40"/>
+            <param name="asm|g" value="10000"/>
             <output name="assembly_info" file="result3_assembly_info.txt" ftype="tabular" compare="sim_size"/>
             <output name="assembly_graph" file="result3_assembly_graph.dot" ftype="graph_dot" compare="sim_size"/>
             <output name="assembly_gfa" file="result3_assembly_graph.gfa" ftype="txt" compare="sim_size"/>
@@ -113,7 +112,6 @@
         <test>
             <param name="inputs" ftype="fasta" value="nanopore.fasta"/>
             <param name="mode" value="--pacbio-raw"/>
-            <param name="g" value="10000"/>
             <param name="i" value="1"/>
             <param name="meta" value="true"/>
             <param name="plasmids" value="true"/>

--- a/tools/flye/flye.xml
+++ b/tools/flye/flye.xml
@@ -29,14 +29,14 @@
     #end for
 
     -o out_dir
-    -g '$g'
     -t \${GALAXY_SLOTS:-4}
     -i $i
     #if $m:
         -m '$m'
     #end if
-    #if $asm:
-        --asm-coverage '$asm'
+    #if str($asm.asm_select) == "true":
+        --asm-coverage '$asm.asm'
+        -g '$asm.g'
     #end if
     ${plasmids}
     ${meta}
@@ -52,12 +52,23 @@
             <option value="--pacbio-corr">PacBio corrected</option>
             <option value="--subassemblies">high-quality contig-like input</option>
         </param>
-        <param argument="-g" type="text" label="estimated genome size (for example, 5m or 2.6g)">
-            <validator type="regex" message="Genome size must be a float  or integer, optionally followed by the a unit prefix (kmg)">^([0-9]*[.])?[0-9]+[kmg]?$</validator>
-        </param>
         <param argument="-i" type="integer" value="1" label="number of polishing iterations" />
         <param argument="-m" type="integer" optional="true" label="minimum overlap between reads (default: auto)" />
-        <param name="asm" argument="--asm-coverage" type="integer" optional="true" label="reduced coverage for initial disjointing assembly" />
+
+        <conditional name="asm">
+            <param name="asm_select" type="select" label="description" help="">
+                <option value="true">Enable reduced coverage for initial disjointing assembly</option>
+                <option value="false" selected="true">Disable reduced coverage for initial disjointing assembly</option>
+            </param>
+            <when value="true">
+                <param name="asm" argument="--asm-coverage" type="integer" label="reduced coverage for initial disjointing assembly" />
+                <param argument="-g" type="text" label="estimated genome size (for example, 5m or 2.6g)">
+                    <validator type="regex" message="Genome size must be a float  or integer, optionally followed by the a unit prefix (kmg)">^([0-9]*[.])?[0-9]+[kmg]?$</validator>
+                </param>
+            </when>
+            <when value="false" />
+        </conditional>
+
         <param argument="--plasmids" type="boolean" truevalue="--plasmids" falsevalue="" checked="False" label="rescue short unassembled plasmids" />
         <param argument="--meta" type="boolean" truevalue="--meta" falsevalue="" checked="False" label="perform metagenomic assembly" />
         <param name="no_trestle" argument="--no-trestle" type="boolean" truevalue="--no-trestle" falsevalue="" checked="False" label="skip trestle stage" />

--- a/tools/flye/flye.xml
+++ b/tools/flye/flye.xml
@@ -1,4 +1,4 @@
-<tool id="flye" name="Flye assembly" version="2.6+galaxy0">
+<tool id="flye" name="Flye assembly" version="2.8.2+galaxy0">
     <description>of long and error-prone reads</description>
     <macros>
         <import>macros.xml</import>
@@ -101,9 +101,11 @@
             <param name="inputs" ftype="fasta" value="nanopore.fasta"/>
             <param name="mode" value="--nano-corr"/>
             <param name="i" value="2"/>
-            <param name="asm|asm_select" value="true" />
-            <param name="asm|asm" value="40"/>
-            <param name="asm|g" value="10000"/>
+            <conditional name="asm">
+                <param name="asm_select" value="true" />
+                <param name="asm" value="40"/>
+                <param name="g" value="10000"/>
+            </conditional>
             <output name="assembly_info" file="result3_assembly_info.txt" ftype="tabular" compare="sim_size"/>
             <output name="assembly_graph" file="result3_assembly_graph.dot" ftype="graph_dot" compare="sim_size"/>
             <output name="assembly_gfa" file="result3_assembly_graph.gfa" ftype="txt" compare="sim_size"/>

--- a/tools/flye/macros.xml
+++ b/tools/flye/macros.xml
@@ -1,7 +1,7 @@
 <macros>
     <xml name="requirements">
         <requirements>
-        <requirement type="package" version="2.6">flye</requirement>
+        <requirement type="package" version="2.8.2">flye</requirement>
             <yield/>
         </requirements>
     </xml>


### PR DESCRIPTION
Genome size is no longer required, unless the --asm-coverage option is selected.
