### PR TITLE
Updating chemicaltoolbox/im-pipelines tool version(s)

### DIFF
--- a/chemicaltoolbox/im-pipelines/macros.xml
+++ b/chemicaltoolbox/im-pipelines/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.1.4</token>
+    <token name="@TOOL_VERSION@">1.1.6</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">im-pipelines</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool repo: **chemicaltoolbox/im-pipelines**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

Please see https://github.com/planemo-autoupdate/autoupdate for more information.