### PR TITLE
Updating chemicaltoolbox/rdkit tool version(s)

### DIFF
--- a/chemicaltoolbox/rdkit/enumerate_charges.xml
+++ b/chemicaltoolbox/rdkit/enumerate_charges.xml
@@ -1,7 +1,7 @@
 <tool id="enumerate_charges" name="Enumerate changes" version="@TOOL_VERSION@+galaxy@GALAXY_VERSION@">
     <description>calculated with Dimorphite DL and RDKit</description>
     <macros>
-        <token name="@TOOL_VERSION@">2020.03.4</token>
+        <token name="@TOOL_VERSION@">2020.09.5</token>
         <token name="@GALAXY_VERSION@">0</token>
     </macros>
       <requirements>

--- a/chemicaltoolbox/rdkit/rdkit_descriptors.xml
+++ b/chemicaltoolbox/rdkit/rdkit_descriptors.xml
@@ -1,8 +1,8 @@
 <tool id="ctb_rdkit_descriptors" name="Descriptors" version="@TOOL_VERSION@+galaxy@GALAXY_VERSION@">
     <description>calculated with RDKit</description>
     <macros>
-        <token name="@TOOL_VERSION@">2020.03.4</token>
-        <token name="@GALAXY_VERSION@">1</token>
+        <token name="@TOOL_VERSION@">2020.09.5</token>
+        <token name="@GALAXY_VERSION@">0</token>
     </macros>
     <!--parallelism method="multi" split_inputs="infile" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="outfile"></parallelism-->
     <requirements>

--- a/chemicaltoolbox/rdkit/sdf_to_tab.xml
+++ b/chemicaltoolbox/rdkit/sdf_to_tab.xml
@@ -1,6 +1,6 @@
 <tool id="sdf_to_tab" name="Extract values from an SD-file" version="@TOOL_VERSION@+galaxy@GALAXY_VERSION@">
     <macros>
-        <token name="@TOOL_VERSION@">2020.03.4</token>
+        <token name="@TOOL_VERSION@">2020.09.5</token>
         <token name="@GALAXY_VERSION@">0</token>
     </macros>
     <description>into a tabular file using RDKit</description>


### PR DESCRIPTION
Hello! This is an automated update of the following tool repo: **chemicaltoolbox/rdkit**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

Please see https://github.com/planemo-autoupdate/autoupdate for more information.