### PR TITLE
Updating chemicaltoolbox/rdock tool version(s)

### DIFF
--- a/chemicaltoolbox/rdock/rdock_macros.xml
+++ b/chemicaltoolbox/rdock/rdock_macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2013.1-0</token>
+    <token name="@TOOL_VERSION@">2013.1</token>
     <xml name="citations">
         <citations>
             <citation type="doi">10.1371/journal.pcbi.1003571</citation>


### PR DESCRIPTION
Hello! This is an automated update of the following tool repo: **chemicaltoolbox/rdock**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

Please see https://github.com/planemo-autoupdate/autoupdate for more information.