### PR TITLE
Updating chemicaltoolbox/silicos-it/qed tool version(s)

### DIFF
--- a/chemicaltoolbox/silicos-it/qed/silicos_qed.xml
+++ b/chemicaltoolbox/silicos-it/qed/silicos_qed.xml
@@ -1,6 +1,6 @@
 <tool id="ctb_silicos_qed" name="Drug-likeness" version="@TOOL_VERSION@+galaxy@GALAXY_VERSION@">
     <macros>
-        <token name="@TOOL_VERSION@">2019.03.1</token>
+        <token name="@TOOL_VERSION@">2020.09.5</token>
         <token name="@GALAXY_VERSION@">0</token>
     </macros>
     <description>quantitative estimation (QED) with RDKit</description>


### PR DESCRIPTION
Hello! This is an automated update of the following tool repo: **chemicaltoolbox/silicos-it/qed**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

Please see https://github.com/planemo-autoupdate/autoupdate for more information.