### PR TITLE
Updating chemicaltoolbox/autodock_vina/prepare_box tool version(s)

### DIFF
--- a/chemicaltoolbox/autodock_vina/prepare_box/prepare_box.xml
+++ b/chemicaltoolbox/autodock_vina/prepare_box/prepare_box.xml
@@ -1,12 +1,12 @@
 <tool id="prepare_box" name="Calculate the box parameters using RDKit" version="@TOOL_VERSION@+galaxy@GALAXY_VERSION@">
     <macros>
-        <token name="@TOOL_VERSION@">2020.03.4</token>
+        <token name="@TOOL_VERSION@">2020.09.5</token>
         <token name="@GALAXY_VERSION@">0</token>
     </macros>
     <description>for an AutoDock Vina job from a ligand input file (confounding box)</description>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">rdkit</requirement>
-        <requirement type="package" version="1.19.1">numpy</requirement>
+        <requirement type="package" version="1.20.1">numpy</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
         python '$__tool_directory__/calc_vina_box_params.py'


### PR DESCRIPTION
Hello! This is an automated update of the following tool repo: **chemicaltoolbox/autodock_vina/prepare_box**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

Please see https://github.com/planemo-autoupdate/autoupdate for more information.