### PR TITLE
Allow special characters as Create text file input

### DIFF
--- a/tools/text_processing/text_processing/macros.xml
+++ b/tools/text_processing/text_processing/macros.xml
@@ -16,6 +16,16 @@
             <regex match="Exception:" />
         </stdio>
     </xml>
+    <xml name="sanitize_text">
+        <sanitizer invalid_char="">
+            <valid initial="string.printable">
+                <remove value="&apos;" />
+            </valid>
+            <mapping initial="none">
+                <add source="&apos;" target="&apos;&quot;&apos;&quot;&apos;" />
+            </mapping>
+       </sanitizer>
+    </xml>
     <token name="@REFERENCES@">
 <![CDATA[
 ------

--- a/tools/text_processing/text_processing/recurring_lines.xml
+++ b/tools/text_processing/text_processing/recurring_lines.xml
@@ -9,18 +9,20 @@
 <![CDATA[
         #for $token in $token_set:
             #if str($token.repeat_select.repeat_select_opts) == 'user':
-                times=#echo $token.repeat_select.times#;
+                times=${token.repeat_select.times};
             #else:
-                times=`wc -l $token.repeat_select.infile | awk '{print $1}'`;
+                times=`wc -l '$token.repeat_select.infile' | awk '{print $1}'`;
             #end if
-            yes -- "${token.line}" 2>/dev/null | head -n \$times >> $outfile;
+            yes -- '${token.line}' 2>/dev/null | head -n \$times >> '$outfile';
         #end for
 ]]>
     </command>
     <inputs>
         <repeat name="token_set" title=" selection" min="1">
             <param name="line" type="text"
-                label="Characters to insert" help="Specify the characters that will be inserted X times in every line"/>
+                label="Characters to insert" help="Specify the characters that will be inserted X times in every line">
+                <expand macro="sanitize_text" />
+            </param>
             <conditional name="repeat_select">
                 <param name="repeat_select_opts" type="select" label="Specify the number of iterations by">
                     <option value="file">File (for each line in file)</option>
@@ -43,23 +45,39 @@
         <test>
             <repeat name="token_set">
                 <param name="line" value="freedom" />
-                <param name="repeat_select_opts" value="file" />
-                <param name="infile" value="multijoin2.txt" />
+                <conditional name="repeat_select">
+                    <param name="repeat_select_opts" value="file" />
+                    <param name="infile" value="multijoin2.txt" />
+                </conditional>
             </repeat>
             <output name="outfile" file="recurring_result1.txt" />
         </test>
         <test>
             <repeat name="token_set">
                 <param name="line" value="freedom" />
-                <param name="repeat_select_opts" value="user" />
-                <param name="times" value="10" />
+                <conditional name="repeat_select">
+                    <param name="repeat_select_opts" value="user" />
+                    <param name="times" value="10" />
+                </conditional>
             </repeat>
             <repeat name="token_set">
                 <param name="line" value="war is over" />
-                <param name="repeat_select_opts" value="user" />
-                <param name="times" value="10" />
+                <conditional name="repeat_select">
+                    <param name="repeat_select_opts" value="user" />
+                    <param name="times" value="10" />
+                </conditional>
             </repeat>
             <output name="outfile" file="recurring_result2.txt" />
+        </test>
+        <test>
+            <repeat name="token_set">
+                <param name="line" value="it ain't over 'til it's over" />
+                <conditional name="repeat_select">
+                    <param name="repeat_select_opts" value="user" />
+                    <param name="times" value="3" />
+                </conditional>
+            </repeat>
+            <output name="outfile" file="recurring_result3.txt" />
         </test>
     </tests>
     <help>

--- a/tools/text_processing/text_processing/test-data/recurring_result1.txt
+++ b/tools/text_processing/text_processing/test-data/recurring_result1.txt
@@ -7,4 +7,3 @@ freedom
 freedom
 freedom
 freedom
-freedom

--- a/tools/text_processing/text_processing/test-data/recurring_result3.txt
+++ b/tools/text_processing/text_processing/test-data/recurring_result3.txt
@@ -1,0 +1,3 @@
+it ain't over 'til it's over
+it ain't over 'til it's over
+it ain't over 'til it's over


### PR DESCRIPTION
This change allows arbitrary characters as tool input without
compromising safety against malicious text.

The added test revealed a bug in the existing tests, which only tested
against default settings.

The newly added "sanitize_text" macro may be useful for other tools here, too.