### PR TITLE
Updating tools/rna_tools/miRDeep2/miRDeep2 tool version(s)

### DIFF
--- a/tools/rna_tools/miRDeep2/miRDeep2/mirdeep2.xml
+++ b/tools/rna_tools/miRDeep2/miRDeep2/mirdeep2.xml
@@ -1,6 +1,6 @@
 <tool id="rbc_mirdeep2" name="MiRDeep2" version="@TOOL_VERSION@+galaxy@GALAXY_VERSION@">
     <macros>
-        <token name="@TOOL_VERSION@">2.0.1.2</token>
+        <token name="@TOOL_VERSION@">2.0.1.3</token>
         <token name="@GALAXY_VERSION@">0</token>
     </macros>
     <description>identification of novel and known miRNAs</description>


### PR DESCRIPTION
Hello! This is an automated update of the following tool repo: **tools/rna_tools/miRDeep2/miRDeep2**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

Please see https://github.com/planemo-autoupdate/autoupdate for more information.