### PR TITLE
Bismark: Fix subprocess command

### DIFF
--- a/tools/bismark/bismark_wrapper.py
+++ b/tools/bismark/bismark_wrapper.py
@@ -367,7 +367,7 @@ def __main__():
                 str(args.num_threads),
                 "-f",
                 tmp_res,
-                " ".join(bam_files),
+                ",".join(bam_files),
             ]
             logger.info("Merging bams with: '%s'", cmd)
             process = subprocess.Popen(


### PR DESCRIPTION
This PR fixes an error in the generation of the subprocess command used for merging the bam files.