### PR TITLE
Update prepare_box tool

### DIFF
--- a/chemicaltoolbox/autodock_vina/prepare_box/prepare_box.xml
+++ b/chemicaltoolbox/autodock_vina/prepare_box/prepare_box.xml
@@ -1,9 +1,9 @@
 <tool id="prepare_box" name="Calculate the box parameters using RDKit" version="@TOOL_VERSION@+galaxy@GALAXY_VERSION@">
     <macros>
-        <token name="@TOOL_VERSION@">2021.03.4</token>
+        <token name="@TOOL_VERSION@">2021.03.5</token>
         <token name="@GALAXY_VERSION@">0</token>
     </macros>
-    <description>for an AutoDock Vina job from a ligand input file (confounding box)</description>
+    <description>for an AutoDock Vina job from a ligand or pocket input file (confounding box)</description>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">rdkit</requirement>
         <requirement type="package" version="1.19.1">numpy</requirement>
@@ -24,8 +24,8 @@
         #end if
     ]]></command>
     <inputs>
-        <param type="data" name="ligand" format="mol,sdf,pdb,mol2" label="Input ligand"
-            help="The input ligand with three-dimensional coordinates (MOL, SDF, PDB and MOL formats supported)."/>
+        <param type="data" name="ligand" format="mol,sdf,pdb,mol2" label="Input ligand or pocket"
+            help="The input ligand or pocket with three-dimensional coordinates (MOL, SDF, PDB and MOL formats supported)."/>
         <param name="bufx" type="float" value="0" label="x-axis buffer"
             help="Buffer in the x direction (in angs.)"/>
         <param name="bufy" type="float" value="0" label="y-axis buffer"
@@ -81,8 +81,12 @@
 
 **Description**
 
-This tool calculates a confounding box around an input ligand and
+This tool calculates a confounding box around an input ligand or pocket and
 uses it to generate the input parameters for an AutoDock Vina job.
+
+If you already know the coordinates of a ligand which binds to the protein, you can simply
+use this file as the tool input. Alternatively, you can search for pockets using the fpocket
+tool and use one of the output PDB files as an input.
 
 The output file can be fed into the AutoDock Vina tool as an alternative to creating the
 parameter file manually.
@@ -95,7 +99,7 @@ parameter file manually.
 
 This tool requires:
 
-* An input ligand - This should be a file (MOL, SDF, PDB or MOL2 format) representing the ligand you wish to dock.
+* An input file (MOL, SDF, PDB or MOL2 format) representing either a ligand, or a pocket found with the fpocket tool.
 
 * (OPTIONAL) Buffers for each direction (x,y,z), which defaults to 0 Å. This value will be added to the confounding box that the tool generates in each respective direction. We recommend that you visualise the calculated box from an initial run of this tool, and calculate the expansion needed in each direction to cover the area of the binding site you wish to explore.
 


### PR DESCRIPTION
Update documentation of prepare_box tool to make it clear that files defining a protein pocket can be used as input, not just ligands.

I will update the training material as well.

ping @chrisbarnettster 