### PR TITLE
fix: cmfinder writing to inputdir

### DIFF
--- a/tools/GraphClust/AlignCluster/align_cluster.xml
+++ b/tools/GraphClust/AlignCluster/align_cluster.xml
@@ -102,12 +102,12 @@
           <when value="yes" >
               <param format="fasta" name="transcript_loci_fasta" type="data" label="Loci reference sequence"
                 help="Sequence of reference species (human) for the genomic loci (precursor mRNA/lncRNA) to locate the clusters" />
-              <param name='transcript_loci_bed' type="text" value="chr1 0 100000 gene 0 +" 
+              <param name='transcript_loci_bed' type="txt" value="chr1 0 100000 gene 0 +" 
                 help="bed entry string of the reference transcript loci for bed/ucsc-track output. 'chrom start end name score strand' white-space separated.">
                 <validator type="regex" message="one-line bed string must have at least 6 entries as BED6 format (chrom start end name 0 strand) 
                 (space and tab allowed)">^\S+\s+[0-9]+\s+[0-9]+\s+\S+\s+\S+\s+[-+]\s*$</validator> 
               </param>
-              <param name='genome_version' value="hg38" type="text" label="reference genome assembly"
+              <param name='genome_version' value="hg38" type="txt" label="reference genome assembly"
                 help="ucsc reference genome assembly version used in the input MAF alignments (e.g. hg38, hg19, mm10). To identify the reference in clusters">
                   <validator type="regex" message="ucsc genome assembly version has an alphabet prefix and a number suffix">^[a-zA-Z]+[0-9]+$</validator> 
               </param>

--- a/tools/GraphClust/CMFinder/cmFinder.xml
+++ b/tools/GraphClust/CMFinder/cmFinder.xml
@@ -9,9 +9,9 @@
     </stdio>
     <command>
     <![CDATA[
-
+        ln -s '$model_tree_stk' 'model_tree.stk' &&
         python '$__tool_directory__/cmFinder.py'
-            '$model_tree_stk'
+            'model_tree.stk'
             '$cmfinder_fa'
             ''
             $gap_threshold_opts.gap_threshold_opts_selector
@@ -22,7 +22,7 @@
     </command>
     <inputs>
         <param name="model_tree_stk" type="data"  format="stockholm" label="model_tree_stk" help="" />
-        <param name="cmfinder_fa" type="data"  format="text" label="cmfinder_fa" help="" />
+        <param name="cmfinder_fa" type="data"  format="txt" label="cmfinder_fa" help="" />
         <conditional name="gap_threshold_opts">
             <param name="gap_threshold_opts_selector" type="select" label="Use gap threshold" help="">
                 <option value="--g" selected="true">Yes (--g)</option>

--- a/tools/GraphClust/GSPAN/fasta2shrep_gspan.xml
+++ b/tools/GraphClust/GSPAN/fasta2shrep_gspan.xml
@@ -35,7 +35,7 @@
         <param name="M" type="integer" value="5" label="Max number of shreps that should be taken per window." help="-M"/>
         <param name="rel_energy_range" type="integer" value="20"
             label=" Relative energy range, i.e. percentage (%) of MFE energy (RNAshapes)" help="-c"/>
-        <param name="wins" type="text" value="40,150"
+        <param name="wins" type="txt" value="40,150"
             label=" A list of window sizes to use" help="comma separated integers"/>
         <param name="shift" type="integer" value="30"
             label="The shift of the window, relative to the window size given inpercent." help="by default 30"/>

--- a/tools/GraphClust/LocARNAGraphClust/locarna_best_subtree.xml
+++ b/tools/GraphClust/LocARNAGraphClust/locarna_best_subtree.xml
@@ -36,8 +36,8 @@
   </command>
   <inputs>
     <param type="data" name="center_fa_file" label="centers" format="fa, fasta" help="fasta format" />
-    <param type="data" name="tree_file" label="trees" format="text" help="text format" />
-    <param type="data" name="tree_matrix" label="tree_matrix" format="text" help="text format" />
+    <param type="data" name="tree_file" label="trees" format="txt" help="text format" />
+    <param type="data" name="tree_matrix" label="tree_matrix" format="txt" help="text format" />
     <param type="data" name="data_map" label="data_map" format="txt" help="text format" />
     <param name="allow_overlap" type="boolean"  truevalue="1" falsevalue="0" label="Allow overlap in subtrees" help="otherwise ignore subtree if it contains overlapping sequences"/>
 

--- a/tools/GraphClust/Structure_GSPAN/structure_to_gspan.xml
+++ b/tools/GraphClust/Structure_GSPAN/structure_to_gspan.xml
@@ -20,9 +20,9 @@
     </command>
     <inputs>
         <param type="data" name="dataFile" format="dbn" label="Sequence and Structure input file in the prediction tool format" />
-        <param name="inputFormat" type="text" value="vrna-simple"
+        <param name="inputFormat" type="txt" value="vrna-simple"
             label="  Sequence Structure format of the input. Allowed formats: vrna-simple, vrna-mea" help="-input-format"/>
-        <param name="structureType" type="text" value="MFE"
+        <param name="structureType" type="txt" value="MFE"
             label="  Sequence Structure type from the input to use. Allowed types: MFE, MEA" help="-input-structure-type"/>
         <param argument="-stack" truevalue="-stack" falsevalue="" checked="true"  type="boolean"
             label="Add stacking information to graphs"/>


### PR DESCRIPTION
I didn't any datatype named `text`. Hence, changed from `format="text"` to `format="txt"`. Does it make sense?