### PR TITLE
Updating chemicaltoolbox/autodock_vina/docking from version 1.2.2 to 1.2.3

### DIFF
--- a/chemicaltoolbox/autodock_vina/docking/docking.xml
+++ b/chemicaltoolbox/autodock_vina/docking/docking.xml
@@ -1,14 +1,14 @@
 <tool id="docking" name="VINA Docking" version="@TOOL_VERSION@+galaxy@GALAXY_VERSION@">
     <description>tool to perform protein-ligand docking with Autodock Vina</description>
     <macros>
-        <token name="@TOOL_VERSION@">1.2.2</token>
+        <token name="@TOOL_VERSION@">1.2.3</token>
         <token name="@GALAXY_VERSION@">0</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">vina</requirement>
         <requirement type="package" version="3.9">python</requirement>
         <requirement type="package" version="3.1.1">openbabel</requirement>
-        <requirement type="package" version="20210822">parallel</requirement>
+        <requirement type="package" version="20211022">parallel</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
         #if $ligands.is_of_type("sdf")

--- a/chemicaltoolbox/autodock_vina/docking/test-data/ligand1_docked_flex.pdbqt
+++ b/chemicaltoolbox/autodock_vina/docking/test-data/ligand1_docked_flex.pdbqt
@@ -1,7 +1,7 @@
 MODEL 1
-REMARK VINA RESULT:   -10.316      0.000      0.000
-REMARK INTER + INTRA:         -14.293
-REMARK INTER:                 -12.644
+REMARK VINA RESULT:    -9.488      0.000      0.000
+REMARK INTER + INTRA:         -13.271
+REMARK INTER:                 -11.622
 REMARK INTRA:                  -1.650
 REMARK UNBOUND:                -1.564
 REMARK  Name = 
@@ -62,9 +62,9 @@ ENDBRANCH   1   2
 END_RES THR A 315
 ENDMDL
 MODEL 2
-REMARK VINA RESULT:    -9.515      3.038      6.782
-REMARK INTER + INTRA:         -13.304
-REMARK INTER:                 -11.867
+REMARK VINA RESULT:    -8.686      3.038      6.782
+REMARK INTER + INTRA:         -12.281
+REMARK INTER:                 -10.844
 REMARK INTRA:                  -1.437
 REMARK UNBOUND:                -1.564
 REMARK  Name = 
@@ -125,9 +125,9 @@ ENDBRANCH   1   2
 END_RES THR A 315
 ENDMDL
 MODEL 3
-REMARK VINA RESULT:    -9.455      3.039      6.858
-REMARK INTER + INTRA:         -13.230
-REMARK INTER:                 -11.911
+REMARK VINA RESULT:    -8.632      3.039      6.858
+REMARK INTER + INTRA:         -12.215
+REMARK INTER:                 -10.896
 REMARK INTRA:                  -1.319
 REMARK UNBOUND:                -1.564
 REMARK  Name = 
@@ -188,9 +188,9 @@ ENDBRANCH   1   2
 END_RES THR A 315
 ENDMDL
 MODEL 4
-REMARK VINA RESULT:    -7.535      6.262      8.774
-REMARK INTER + INTRA:         -10.861
-REMARK INTER:                  -9.173
+REMARK VINA RESULT:    -6.697      6.262      8.774
+REMARK INTER + INTRA:          -9.828
+REMARK INTER:                  -8.140
 REMARK INTRA:                  -1.688
 REMARK UNBOUND:                -1.564
 REMARK  Name = 
@@ -251,9 +251,9 @@ ENDBRANCH   1   2
 END_RES THR A 315
 ENDMDL
 MODEL 5
-REMARK VINA RESULT:    -7.505      3.113      4.658
-REMARK INTER + INTRA:         -10.825
-REMARK INTER:                  -9.232
+REMARK VINA RESULT:    -6.680      3.113      4.658
+REMARK INTER + INTRA:          -9.807
+REMARK INTER:                  -8.214
 REMARK INTRA:                  -1.593
 REMARK UNBOUND:                -1.564
 REMARK  Name = 
@@ -314,9 +314,9 @@ ENDBRANCH   1   2
 END_RES THR A 315
 ENDMDL
 MODEL 6
-REMARK VINA RESULT:    -7.486      3.560      7.618
-REMARK INTER + INTRA:         -10.800
-REMARK INTER:                  -9.187
+REMARK VINA RESULT:    -6.663      3.560      7.618
+REMARK INTER + INTRA:          -9.786
+REMARK INTER:                  -8.172
 REMARK INTRA:                  -1.614
 REMARK UNBOUND:                -1.564
 REMARK  Name = 
@@ -377,9 +377,9 @@ ENDBRANCH   1   2
 END_RES THR A 315
 ENDMDL
 MODEL 7
-REMARK VINA RESULT:    -7.477      3.361      7.397
-REMARK INTER + INTRA:         -10.790
-REMARK INTER:                  -9.755
+REMARK VINA RESULT:    -6.646      3.361      7.397
+REMARK INTER + INTRA:          -9.765
+REMARK INTER:                  -8.730
 REMARK INTRA:                  -1.035
 REMARK UNBOUND:                -1.564
 REMARK  Name = 
@@ -440,9 +440,9 @@ ENDBRANCH   1   2
 END_RES THR A 315
 ENDMDL
 MODEL 8
-REMARK VINA RESULT:    -7.400      7.777     12.519
-REMARK INTER + INTRA:         -10.695
-REMARK INTER:                  -9.104
+REMARK VINA RESULT:    -6.566      7.777     12.519
+REMARK INTER + INTRA:          -9.666
+REMARK INTER:                  -8.075
 REMARK INTRA:                  -1.591
 REMARK UNBOUND:                -1.564
 REMARK  Name = 
@@ -498,6 +498,69 @@ ATOM      3  CG2 THR A 315      13.568  51.713  10.440  1.00 42.73     0.042 C
 BRANCH   2   4
 ATOM      4  OG1 THR A 315      14.631  53.679   9.556  1.00 47.20    -0.393 OA
 ATOM      5  HG1 THR A 315      14.438  54.491   9.650  1.00 47.20     0.210 HD
+ENDBRANCH   2   4
+ENDBRANCH   1   2
+END_RES THR A 315
+ENDMDL
+MODEL 9
+REMARK VINA RESULT:    -6.512      5.842      9.536
+REMARK INTER + INTRA:          -9.599
+REMARK INTER:                  -8.034
+REMARK INTRA:                  -1.564
+REMARK UNBOUND:                -1.564
+REMARK  Name = 
+REMARK  5 active torsions:
+REMARK  status: ('A' for Active; 'I' for Inactive)
+REMARK    1  A    between atoms: C_1  and  C_8
+REMARK    2  A    between atoms: C_2  and  C_13
+REMARK    3  A    between atoms: C_8  and  C_9
+REMARK    4  A    between atoms: C_8  and  O_18
+REMARK    5  A    between atoms: C_10  and  O_18
+REMARK                            x       y       z     vdW  Elec       q    Type
+REMARK                         _______ _______ _______ _____ _____    ______ ____
+ROOT
+ATOM      1  C   UNL     1      15.749  50.967  15.559  0.00  0.00    +0.000 A 
+ATOM      2  C   UNL     1      14.383  50.812  15.783  0.00  0.00    +0.000 A 
+ATOM      3  C   UNL     1      13.949  49.822  16.652  0.00  0.00    +0.000 A 
+ATOM      4  C   UNL     1      14.843  48.966  17.310  0.00  0.00    +0.000 A 
+ATOM      5  C   UNL     1      16.210  49.146  17.063  0.00  0.00    +0.000 A 
+ATOM      6  C   UNL     1      16.663  50.133  16.201  0.00  0.00    +0.000 A 
+ENDROOT
+BRANCH   4   7
+ATOM      7  C   UNL     1      14.350  47.908  18.239  0.00  0.00    +0.000 A 
+ATOM      8  C   UNL     1      13.052  47.958  18.756  0.00  0.00    +0.000 A 
+ATOM      9  C   UNL     1      12.584  46.981  19.627  0.00  0.00    +0.000 A 
+ATOM     10  C   UNL     1      13.410  45.935  20.004  0.00  0.00    +0.000 A 
+ATOM     11  C   UNL     1      14.695  45.866  19.504  0.00  0.00    +0.000 A 
+ATOM     12  C   UNL     1      15.166  46.843  18.633  0.00  0.00    +0.000 A 
+ENDBRANCH   4   7
+BRANCH   1  13
+ATOM     13  O   UNL     1      16.214  51.944  14.707  0.00  0.00    +0.000 OA
+BRANCH  13  15
+ATOM     14  C   UNL     1      16.652  51.842  12.389  0.00  0.00    +0.000 C 
+ATOM     15  C   UNL     1      15.585  52.104  13.441  0.00  0.00    +0.000 C 
+BRANCH  15  16
+ATOM     16  C   UNL     1      14.999  53.512  13.390  0.00  0.00    +0.000 C 
+ATOM     17  O   UNL     1      15.424  54.269  12.497  0.00  0.00    +0.000 OA
+ATOM     18  O   UNL     1      14.125  53.806  14.230  0.00  0.00    +0.000 OA
+ENDBRANCH  15  16
+ENDBRANCH  13  15
+ENDBRANCH   1  13
+TORSDOF 4
+BEGIN_RES THR A 315
+REMARK  2 active torsions:
+REMARK  status: ('A' for Active; 'I' for Inactive)
+REMARK    1  A    between atoms: CA   and  CB  
+REMARK    2  A    between atoms: CB   and  OG1 
+ROOT
+ATOM      1  CA  THR A 315      13.079  52.503   8.093  1.00 45.40     0.205 C 
+ENDROOT
+BRANCH   1   2
+ATOM      2  CB  THR A 315      13.429  52.900   9.553  1.00 45.76     0.146 C 
+ATOM      3  CG2 THR A 315      13.346  51.743  10.485  1.00 42.73     0.042 C 
+BRANCH   2   4
+ATOM      4  OG1 THR A 315      14.737  53.484   9.584  1.00 47.20    -0.393 OA
+ATOM      5  HG1 THR A 315      15.314  52.876   9.641  1.00 47.20     0.210 HD
 ENDBRANCH   2   4
 ENDBRANCH   1   2
 END_RES THR A 315

--- a/chemicaltoolbox/autodock_vina/docking/test-data/ligand2_docked_flex.pdbqt
+++ b/chemicaltoolbox/autodock_vina/docking/test-data/ligand2_docked_flex.pdbqt
@@ -1,7 +1,7 @@
 MODEL 1
-REMARK VINA RESULT:    -8.478      0.000      0.000
-REMARK INTER + INTRA:         -11.272
-REMARK INTER:                  -9.987
+REMARK VINA RESULT:    -7.600      0.000      0.000
+REMARK INTER + INTRA:         -10.239
+REMARK INTER:                  -8.955
 REMARK INTRA:                  -1.284
 REMARK UNBOUND:                -1.307
 REMARK  Name = 
@@ -60,9 +60,9 @@ ENDBRANCH   1   2
 END_RES THR A 315
 ENDMDL
 MODEL 2
-REMARK VINA RESULT:    -8.335      1.384      2.651
-REMARK INTER + INTRA:         -11.104
-REMARK INTER:                 -10.039
+REMARK VINA RESULT:    -7.516      1.384      2.651
+REMARK INTER + INTRA:         -10.141
+REMARK INTER:                  -9.075
 REMARK INTRA:                  -1.066
 REMARK UNBOUND:                -1.307
 REMARK  Name = 
@@ -121,9 +121,9 @@ ENDBRANCH   1   2
 END_RES THR A 315
 ENDMDL
 MODEL 3
-REMARK VINA RESULT:    -7.642      2.889      5.304
-REMARK INTER + INTRA:         -10.290
-REMARK INTER:                  -9.066
+REMARK VINA RESULT:    -6.774      2.889      5.304
+REMARK INTER + INTRA:          -9.269
+REMARK INTER:                  -8.046
 REMARK INTRA:                  -1.224
 REMARK UNBOUND:                -1.307
 REMARK  Name = 
@@ -182,9 +182,9 @@ ENDBRANCH   1   2
 END_RES THR A 315
 ENDMDL
 MODEL 4
-REMARK VINA RESULT:    -7.588      3.116      5.861
-REMARK INTER + INTRA:         -10.226
-REMARK INTER:                  -9.000
+REMARK VINA RESULT:    -6.724      3.116      5.861
+REMARK INTER + INTRA:          -9.211
+REMARK INTER:                  -7.984
 REMARK INTRA:                  -1.226
 REMARK UNBOUND:                -1.307
 REMARK  Name = 
@@ -243,9 +243,9 @@ ENDBRANCH   1   2
 END_RES THR A 315
 ENDMDL
 MODEL 5
-REMARK VINA RESULT:    -7.195      7.573      9.922
-REMARK INTER + INTRA:          -9.764
-REMARK INTER:                  -8.550
+REMARK VINA RESULT:    -6.332      7.573      9.922
+REMARK INTER + INTRA:          -8.749
+REMARK INTER:                  -7.535
 REMARK INTRA:                  -1.214
 REMARK UNBOUND:                -1.307
 REMARK  Name = 
@@ -304,9 +304,9 @@ ENDBRANCH   1   2
 END_RES THR A 315
 ENDMDL
 MODEL 6
-REMARK VINA RESULT:    -6.877      2.472      5.340
-REMARK INTER + INTRA:          -9.390
-REMARK INTER:                  -8.396
+REMARK VINA RESULT:    -6.052      2.472      5.340
+REMARK INTER + INTRA:          -8.420
+REMARK INTER:                  -7.426
 REMARK INTRA:                  -0.994
 REMARK UNBOUND:                -1.307
 REMARK  Name = 
@@ -365,70 +365,9 @@ ENDBRANCH   1   2
 END_RES THR A 315
 ENDMDL
 MODEL 7
-REMARK VINA RESULT:    -6.551      7.869      9.649
-REMARK INTER + INTRA:          -9.006
-REMARK INTER:                  -7.655
-REMARK INTRA:                  -1.351
-REMARK UNBOUND:                -1.307
-REMARK  Name = 
-REMARK  7 active torsions:
-REMARK  status: ('A' for Active; 'I' for Inactive)
-REMARK    1  A    between atoms: C_1  and  C_5
-REMARK    2  A    between atoms: C_2  and  C_12
-REMARK    3  A    between atoms: C_2  and  O_15
-REMARK    4  A    between atoms: C_3  and  O_15
-REMARK    5  A    between atoms: C_4  and  C_7
-REMARK    6  A    between atoms: C_8  and  N_13
-REMARK    7  A    between atoms: C_9  and  C_11
-REMARK                            x       y       z     vdW  Elec       q    Type
-REMARK                         _______ _______ _______ _____ _____    ______ ____
-ROOT
-ATOM      1  C   UNL     1      15.224  51.234  15.258  0.00  0.00    +0.000 C 
-ATOM      2  C   UNL     1      17.260  47.627  18.110  0.00  0.00    +0.000 C 
-ATOM      3  C   UNL     1      15.058  50.145  16.293  0.00  0.00    +0.000 A 
-ATOM      4  C   UNL     1      16.147  49.405  16.733  0.00  0.00    +0.000 A 
-ATOM      5  C   UNL     1      16.030  48.390  17.679  0.00  0.00    +0.000 A 
-ATOM      6  C   UNL     1      14.750  48.124  18.192  0.00  0.00    +0.000 A 
-ATOM      7  C   UNL     1      13.624  48.846  17.767  0.00  0.00    +0.000 A 
-ATOM      8  C   UNL     1      13.809  49.846  16.816  0.00  0.00    +0.000 A 
-ATOM      9  C   UNL     1      12.242  48.571  18.293  0.00  0.00    +0.000 C 
-ENDROOT
-BRANCH   6  11
-ATOM     10  C   UNL     1      14.805  47.210  20.483  0.00  0.00    +0.000 C 
-ATOM     11  N   UNL     1      14.576  47.086  19.163  0.00  0.00    +0.000 N 
-ATOM     12  O   UNL     1      14.911  48.270  21.085  0.00  0.00    +0.000 OA
-ATOM     13  H   UNL     1      14.264  46.210  18.839  0.00  0.00    +0.000 HD
-BRANCH  10  14
-ATOM     14  C   UNL     1      14.976  45.924  21.245  0.00  0.00    +0.000 C 
-BRANCH  14  16
-ATOM     15  C   UNL     1      17.250  45.349  21.091  0.00  0.00    +0.000 C 
-ATOM     16  O   UNL     1      15.921  45.061  20.664  0.00  0.00    +0.000 OA
-ENDBRANCH  14  16
-ENDBRANCH  10  14
-ENDBRANCH   6  11
-TORSDOF 3
-BEGIN_RES THR A 315
-REMARK  2 active torsions:
-REMARK  status: ('A' for Active; 'I' for Inactive)
-REMARK    1  A    between atoms: CA   and  CB  
-REMARK    2  A    between atoms: CB   and  OG1 
-ROOT
-ATOM      1  CA  THR A 315      13.079  52.503   8.093  1.00 45.40     0.205 C 
-ENDROOT
-BRANCH   1   2
-ATOM      2  CB  THR A 315      13.429  52.900   9.553  1.00 45.76     0.146 C 
-ATOM      3  CG2 THR A 315      13.581  51.713  10.437  1.00 42.73     0.042 C 
-BRANCH   2   4
-ATOM      4  OG1 THR A 315      14.624  53.690   9.555  1.00 47.20    -0.393 OA
-ATOM      5  HG1 THR A 315      15.256  53.241   9.877  1.00 47.20     0.210 HD
-ENDBRANCH   2   4
-ENDBRANCH   1   2
-END_RES THR A 315
-ENDMDL
-MODEL 8
-REMARK VINA RESULT:    -6.550      7.860      9.796
-REMARK INTER + INTRA:          -9.006
-REMARK INTER:                  -7.662
+REMARK VINA RESULT:    -5.678      7.860      9.796
+REMARK INTER + INTRA:          -7.981
+REMARK INTER:                  -6.637
 REMARK INTRA:                  -1.344
 REMARK UNBOUND:                -1.307
 REMARK  Name = 
@@ -486,10 +425,71 @@ ENDBRANCH   2   4
 ENDBRANCH   1   2
 END_RES THR A 315
 ENDMDL
+MODEL 8
+REMARK VINA RESULT:    -5.677      7.869      9.649
+REMARK INTER + INTRA:          -7.980
+REMARK INTER:                  -6.628
+REMARK INTRA:                  -1.351
+REMARK UNBOUND:                -1.307
+REMARK  Name = 
+REMARK  7 active torsions:
+REMARK  status: ('A' for Active; 'I' for Inactive)
+REMARK    1  A    between atoms: C_1  and  C_5
+REMARK    2  A    between atoms: C_2  and  C_12
+REMARK    3  A    between atoms: C_2  and  O_15
+REMARK    4  A    between atoms: C_3  and  O_15
+REMARK    5  A    between atoms: C_4  and  C_7
+REMARK    6  A    between atoms: C_8  and  N_13
+REMARK    7  A    between atoms: C_9  and  C_11
+REMARK                            x       y       z     vdW  Elec       q    Type
+REMARK                         _______ _______ _______ _____ _____    ______ ____
+ROOT
+ATOM      1  C   UNL     1      15.224  51.234  15.258  0.00  0.00    +0.000 C 
+ATOM      2  C   UNL     1      17.260  47.627  18.110  0.00  0.00    +0.000 C 
+ATOM      3  C   UNL     1      15.058  50.145  16.293  0.00  0.00    +0.000 A 
+ATOM      4  C   UNL     1      16.147  49.405  16.733  0.00  0.00    +0.000 A 
+ATOM      5  C   UNL     1      16.030  48.390  17.679  0.00  0.00    +0.000 A 
+ATOM      6  C   UNL     1      14.750  48.124  18.192  0.00  0.00    +0.000 A 
+ATOM      7  C   UNL     1      13.624  48.846  17.767  0.00  0.00    +0.000 A 
+ATOM      8  C   UNL     1      13.809  49.846  16.816  0.00  0.00    +0.000 A 
+ATOM      9  C   UNL     1      12.242  48.571  18.293  0.00  0.00    +0.000 C 
+ENDROOT
+BRANCH   6  11
+ATOM     10  C   UNL     1      14.805  47.210  20.483  0.00  0.00    +0.000 C 
+ATOM     11  N   UNL     1      14.576  47.086  19.163  0.00  0.00    +0.000 N 
+ATOM     12  O   UNL     1      14.911  48.270  21.085  0.00  0.00    +0.000 OA
+ATOM     13  H   UNL     1      14.264  46.210  18.839  0.00  0.00    +0.000 HD
+BRANCH  10  14
+ATOM     14  C   UNL     1      14.976  45.924  21.245  0.00  0.00    +0.000 C 
+BRANCH  14  16
+ATOM     15  C   UNL     1      17.250  45.349  21.091  0.00  0.00    +0.000 C 
+ATOM     16  O   UNL     1      15.921  45.061  20.664  0.00  0.00    +0.000 OA
+ENDBRANCH  14  16
+ENDBRANCH  10  14
+ENDBRANCH   6  11
+TORSDOF 3
+BEGIN_RES THR A 315
+REMARK  2 active torsions:
+REMARK  status: ('A' for Active; 'I' for Inactive)
+REMARK    1  A    between atoms: CA   and  CB  
+REMARK    2  A    between atoms: CB   and  OG1 
+ROOT
+ATOM      1  CA  THR A 315      13.079  52.503   8.093  1.00 45.40     0.205 C 
+ENDROOT
+BRANCH   1   2
+ATOM      2  CB  THR A 315      13.429  52.900   9.553  1.00 45.76     0.146 C 
+ATOM      3  CG2 THR A 315      13.581  51.713  10.437  1.00 42.73     0.042 C 
+BRANCH   2   4
+ATOM      4  OG1 THR A 315      14.624  53.690   9.555  1.00 47.20    -0.393 OA
+ATOM      5  HG1 THR A 315      15.256  53.241   9.877  1.00 47.20     0.210 HD
+ENDBRANCH   2   4
+ENDBRANCH   1   2
+END_RES THR A 315
+ENDMDL
 MODEL 9
-REMARK VINA RESULT:    -6.154      9.402     11.353
-REMARK INTER + INTRA:          -8.540
-REMARK INTER:                  -7.233
+REMARK VINA RESULT:    -5.286      9.402     11.353
+REMARK INTER + INTRA:          -7.520
+REMARK INTER:                  -6.213
 REMARK INTRA:                  -1.307
 REMARK UNBOUND:                -1.307
 REMARK  Name = 


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **chemicaltoolbox/autodock_vina/docking**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated chemicaltoolbox/autodock_vina/docking from version 1.2.2 to 1.2.3.

**Project home page:** http://vina.scripps.edu

**Maintainers:** @simonbray