### PR TITLE
Suppress report printing to standard out in case of UnicodeEncodeError

### DIFF
--- a/tools/trim_galore/trim_galore.xml
+++ b/tools/trim_galore/trim_galore.xml
@@ -52,6 +52,9 @@
 
         trim_galore
 
+        ## prevent report from being printed to stdout as it may contain greek chars like mu
+        --suppress_warn
+
         ## according the develpers 4 cores could be a sweet spot, anything above has diminishing returns
         --cores \${GALAXY_SLOTS:-4}
 


### PR DESCRIPTION
Report contents are now printed to stdout and after trim_galore completes sqlalchemy in the Galaxy venv may complain about latin-1 codec. This is because "micro seconds" for example are written with the standard Greek mu symbol.  Users who desire this output can still get it by selecting to print the report and Galaxy may render the character with '\ufffd'.