### PR TITLE
update bionano_scaffold tests so that they do not fail based on values of 'threads' and 'memory'

### DIFF
--- a/tools/bionano/bionano_scaffold.xml
+++ b/tools/bionano/bionano_scaffold.xml
@@ -477,16 +477,16 @@
                 </assert_contents>
             </output>
             <assert_stdout>
-                <has_text text='attr="maxmem" val0="8"'/>
+                <has_text_matching expression='attr="maxmem" val0="\d+"'/>
             </assert_stdout>
             <assert_stdout>
-                <has_text text='attr="maxthreads" val0="1"'/>
+                <has_text_matching expression='attr="maxthreads" val0="\d+"'/>
             </assert_stdout>
             <assert_stdout>
-                <has_text text='attr="insertThreads" val0="1"'/>
+                <has_text_matching expression='attr="insertThreads" val0="\d+"'/>
             </assert_stdout>
              <assert_stdout>
-                <has_text text='attr="maxvirtmem" val0="8"'/>
+                <has_text_matching expression='attr="maxvirtmem" val0="\d+"'/>
             </assert_stdout>
             <assert_stdout>
                 <has_text text="hybridScaffold"/>
@@ -527,16 +527,16 @@
                     <has_text text="alignmentOrientation" />
                 </assert_contents>
             </output>            <assert_stdout>
-                <has_text text='attr="maxmem" val0="8"'/>
+                <has_text_matching expression='attr="maxmem" val0="\d+"'/>
             </assert_stdout>
             <assert_stdout>
-                <has_text text='attr="maxthreads" val0="1"'/>
+                <has_text_matching expression='attr="maxthreads" val0="\d+"'/>
             </assert_stdout>
             <assert_stdout>
-                <has_text text='attr="insertThreads" val0="1"'/>
+                <has_text_matching expression='attr="insertThreads" val0="\d+"'/>
             </assert_stdout>
              <assert_stdout>
-                <has_text text='attr="maxvirtmem" val0="8"'/>
+                <has_text_matching expression='attr="maxvirtmem" val0="\d+"'/>
             </assert_stdout>
             <assert_stdout>
                 <has_text text="hybridScaffold"/>
@@ -586,16 +586,16 @@
                 </assert_contents>
             </output>
             <assert_stdout>
-                <has_text text='attr="maxmem" val0="8"'/>
+                <has_text_matching expression='attr="maxmem" val0="\d+"'/>
             </assert_stdout>
             <assert_stdout>
-                <has_text text='attr="maxthreads" val0="1"'/>
+                <has_text_matching expression='attr="maxthreads" val0="\d+"'/>
             </assert_stdout>
             <assert_stdout>
-                <has_text text='attr="insertThreads" val0="1"'/>
+                <has_text_matching expression='attr="insertThreads" val0="\d+"'/>
             </assert_stdout>
              <assert_stdout>
-                <has_text text='attr="maxvirtmem" val0="8"'/>
+                <has_text_matching expression='attr="maxvirtmem" val0="\d+"'/>
             </assert_stdout>
             <assert_stdout>
                 <has_text text="hybridScaffold"/>
@@ -643,16 +643,16 @@
                 </assert_contents>
             </output>
             <assert_stdout>
-                <has_text text='attr="maxmem" val0="8"'/>
+                <has_text_matching expression='attr="maxmem" val0="\d+"'/>
             </assert_stdout>
             <assert_stdout>
-                <has_text text='attr="maxthreads" val0="1"'/>
+                <has_text_matching expression='attr="maxthreads" val0="\d+"'/>
             </assert_stdout>
             <assert_stdout>
-                <has_text text='attr="insertThreads" val0="1"'/>
+                <has_text_matching expression='attr="insertThreads" val0="\d+"'/>
             </assert_stdout>
              <assert_stdout>
-                <has_text text='attr="maxvirtmem" val0="8"'/>
+                <has_text_matching expression='attr="maxvirtmem" val0="\d+"'/>
             </assert_stdout>
             <assert_stdout>
                 <has_text text="hybridScaffold"/>
@@ -694,16 +694,16 @@
                 </assert_contents>
             </output>
             <assert_stdout>
-                <has_text text='attr="maxmem" val0="8"'/>
+                <has_text_matching expression='attr="maxmem" val0="\d+"'/>
             </assert_stdout>
             <assert_stdout>
-                <has_text text='attr="maxthreads" val0="1"'/>
+                <has_text_matching expression='attr="maxthreads" val0="\d+"'/>
             </assert_stdout>
             <assert_stdout>
-                <has_text text='attr="insertThreads" val0="1"'/>
+                <has_text_matching expression='attr="insertThreads" val0="\d+"'/>
             </assert_stdout>
              <assert_stdout>
-                <has_text text='attr="maxvirtmem" val0="8"'/>
+                <has_text_matching expression='attr="maxvirtmem" val0="\d+"'/>
             </assert_stdout>
             <assert_stdout>
                 <has_text text="hybridScaffold"/>


### PR DESCRIPTION
The tests contain assertions that stdout contains the exact text `attr="maxmem" val0="8"` for all test jobs.  Quite often this value will not be 8.  Update this and other values to assert that it matches an integer, not a specific integer.