### PR TITLE
Updating tools/racon from version 1.4.20 to 1.5.0

### DIFF
--- a/tools/racon/macros.xml
+++ b/tools/racon/macros.xml
@@ -5,7 +5,7 @@
             <yield/>
         </requirements>
     </xml>
-    <token name="@TOOL_VERSION@">1.4.20</token>
+    <token name="@TOOL_VERSION@">1.5.0</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <xml name="citations">
         <citations>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/racon**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/racon from version 1.4.20 to 1.5.0.

**Project home page:** https://github.com/isovic/racon/releases