### PR TITLE
Adding single and double quotes to valid values for key value args used in Keras tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,17 +42,17 @@ pip install planemo
 
 To run the tests for a specific tool (e.g., pca) in a specific folder (e.g. sklearn)
 ```
-planemo test --docker tools/sklearn/pca.xml
+planemo test --biocontainers tools/sklearn/pca.xml
 ```
 
 To run the tests for all tools in a specific folder (e.g. sklearn)
 ```
-planemo test --docker tools/sklearn
+planemo test --biocontainers tools/sklearn
 ```
 
 To run the tests for all tools in all folders 
 ```
-planemo test --docker tools
+planemo test --biocontainers tools
 ```
 
 3 steps to get your tool into Galaxy - A real-world example

--- a/tools/sklearn/clf_metrics.xml
+++ b/tools/sklearn/clf_metrics.xml
@@ -250,7 +250,6 @@ with open("$outfile", 'w+') as out_file:
                 <expand macro="clf_inputs" multiple1="true" multiple="true" />
                 <section name="options" title="Advanced Options" expanded="False">
                     <expand macro="average">
-                        <option value="macro" selected="true">Calculate metrics for each label, and find their unweighted mean. (macro)</option>
                     </expand>
                 </section>
             </when>

--- a/tools/sklearn/keras_macros.xml
+++ b/tools/sklearn/keras_macros.xml
@@ -701,7 +701,14 @@
   <!--Simple key words text parameters, conbined to reduce UI latency-->
 
   <xml name="simple_kwargs" token_help="Leave blank for default.">
-    <param argument="kwargs" type="text" value="" label="Type in key words arguments if different from the default" help="@HELP@"/>
+    <param argument="kwargs" type="text" value="" label="Type in key words arguments if different from the default" help="@HELP@">
+      <sanitizer>
+        <valid initial="default">
+          <add value="&apos;" />
+          <add value="&quot;" />
+        </valid>
+      </sanitizer>
+    </param>
   </xml>
 
   <!-- Keras CallBacks -->

--- a/tools/sklearn/keras_macros.xml
+++ b/tools/sklearn/keras_macros.xml
@@ -36,7 +36,7 @@
       <option value="tanh" selected="@TANH@">tanh</option>
       <option value="sigmoid">sigmoid</option>
       <option value="hard_sigmoid">hard_sigmoid</option>
-      <option value="exponential">tanh</option>
+      <option value="exponential">exponential</option>
     </param>
   </xml>
 

--- a/tools/sklearn/keras_macros.xml
+++ b/tools/sklearn/keras_macros.xml
@@ -904,7 +904,7 @@
         <option value="sparse_categorical_accuracy">sparse_categorical_accuracy</option>
         <option value="mse">mse / MSE / mean_squared_error</option>
         <option value="mae">mae / MAE / mean_absolute_error</option>
-        <option value="mae">mape / MAPE / mean_absolute_percentage_error</option>
+        <option value="mape">mape / MAPE / mean_absolute_percentage_error</option>
         <option value="cosine_proximity">cosine_proximity</option>
         <option value="cosine">cosine</option>
         <option value="none">none</option>

--- a/tools/sklearn/to_categorical.xml
+++ b/tools/sklearn/to_categorical.xml
@@ -69,7 +69,7 @@
 Converts a class vector (integers) to binary class matrix.
 
 tf.keras.utils.to_categorical(
-    y, num_classes=None, dtype='float32'
+y, num_classes=None, dtype='float32'
 )
 
 E.g. for use with categorical_crossentropy.


### PR DESCRIPTION
I am seeing a problem in ‘Create a deep learning model architecture’ tool, used in workflow for CNN tutorial: 

https://training.galaxyproject.org/training-material/topics/statistics/tutorials/CNN/tutorial.html

In 'Create a deep learning model architecture’ step of the tutorial, in layer 2, I have:

"padding='same'" for “Type in key words arguments if different from the default”

Any text argument (not just padding) fails to parse correctly, whether I use single or double quotes. I get the following error message for double quotes:

NameError
   dict(padding=__dq__same__dq__)
                 ^^^
name '__dq__same__dq__' is not defined
Traceback (most recent call last):
  File "/jetstream2/scratch/test/jobs/1464482/tool_files/keras_deep_learning.py", line 397, in <module>
    config_keras_model(inputs, outfile)
  File "/jetstream2/scratch/test/jobs/1464482/tool_files/keras_deep_learning.py", line 264, in config_keras_model
    model = get_sequential_model(layers_config)
  File "/jetstream2/scratch/test/jobs/1464482/tool_files/keras_deep_learning.py", line 165, in get_sequential_model
    options.update(kwargs)
TypeError: 'NoneType' object is not iterable

This seems to be due to kwargs not allowing single and double quotes. The code change allows that. This is a bit puzzling a the same workflow worked fine in a January 2022 workshop presentation. There are recent changes to lib/galaxy/tools/evaluation.py:build_param_dict(), but I'm not sure whether thats the culprit or not.