### PR TITLE
[RFC] Select compute resource for training deep learning model

### DIFF
--- a/tools/sklearn/keras_macros.xml
+++ b/tools/sklearn/keras_macros.xml
@@ -917,6 +917,16 @@
     </section>
   </xml>
 
+  <!-- Compute resource -->
+  <xml name="tf_compute_resource">
+    <section name="compute_resource" title="Compute resources" expanded="true">
+      <param name="type_compute_resource" type="select" label="Select processing unit" help="Default processing unit is CPU. Select GPU for faster training of a deep learning model.">
+        <option value="tf_cpu" selected="true">CPU (default)</option>
+        <option value="tf_gpu">GPU</option>
+      </param>
+    </section>
+  </xml>
+
  <!--Citation-->
   <xml name="keras_citation">
     <citation type="bibtex">

--- a/tools/sklearn/keras_train_and_eval.py
+++ b/tools/sklearn/keras_train_and_eval.py
@@ -238,7 +238,7 @@ def main(
 
     with open(inputs, "r") as param_handler:
         params = json.load(param_handler)
-    print(params)
+
     #  load estimator
     with open(infile_estimator, "rb") as estimator_handler:
         estimator = load_model(estimator_handler)
@@ -451,8 +451,7 @@ def main(
         ) = train_test_split_none(X_train, y_train, groups_train, **val_split_options)
 
     # train and eval
-    l_gpu = tf.config.list_physical_devices('GPU')
-    if compute_resource == "tf_gpu" and len(l_gpu) > 0:
+    if compute_resource == "tf_gpu":
         with tf.device('/device:gpu:0'):
             estimator = train_test_eval(estimator, exp_scheme, X_train, y_train, X_val, y_val, X_test, y_test)
     else:
@@ -521,12 +520,12 @@ def main(
 
 def train_test_eval(estimator, exp_scheme, X_train, y_train, X_val, y_val, X_test, y_test):
   if hasattr(estimator, "validation_data"):
-        if exp_scheme == "train_val_test":
-            estimator.fit(X_train, y_train, validation_data=(X_val, y_val))
-        else:
-            estimator.fit(X_train, y_train, validation_data=(X_test, y_test))
-    else:
-        estimator.fit(X_train, y_train)
+      if exp_scheme == "train_val_test":
+          estimator.fit(X_train, y_train, validation_data=(X_val, y_val))
+      else:
+          estimator.fit(X_train, y_train, validation_data=(X_test, y_test))
+  else:
+      estimator.fit(X_train, y_train)
   return estimator
 
 

--- a/tools/sklearn/keras_train_and_eval.xml
+++ b/tools/sklearn/keras_train_and_eval.xml
@@ -82,6 +82,7 @@
             <option value="save_estimator" selected="true">Fitted estimator in skeleton and weights, separately</option>
             <option value="save_prediction">True labels and prediction results from evaluation for downstream analysis</option>
         </param>
+        <expand macro="tf_compute_resource" />
     </inputs>
     <outputs>
         <data format="tabular" name="outfile_result" />


### PR DESCRIPTION
I would like to add a section in the "Deep learning training and evaluation conduct deep training and evaluation" tool to take input from users on which compute resources they want to train their deep learning model - CPUs or GPU. The default would be CPUs but if someone wants to use GPUs, it should also be possible. Currently, on the EU server, the default processing is GPU which may cause issues when all of them are occupied and users who would like to run this deep learning tool cannot process their jobs. Therefore, this choice of selection of computing resources would help users optimize their choices of job processing. If they want to use GPUs and none are free at the moment, still they can switch to CPUs and process their jobs. If GPUs are free, users would be able to process their jobs faster. I have tested this in my local machine having CPUs, it works fine. I will run it on a VM to test GPU settings as well. 

However, I am not sure what should we change in the tool_destination YAML file so that it recognises the compute resource type input coming from this tool and automatically creates the right compute resource based on this user preference. Let me know what you think. Thanks!

A similar feature is already implemented here: https://usegalaxy.eu/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fchemteam%2Fgmx_sim%2Fgmx_sim%2F2022%2Bgalaxy0

UI changes:

![compute_resource_dl](https://user-images.githubusercontent.com/3022518/161280445-1b09ec91-299c-4e24-8d4f-ac7a54b9f581.png)

ping @gmauro @bgruening @qiagu @kxk302