### PR TITLE
Update docker container

### DIFF
--- a/tools/jupyter_job/run_jupyter_job.xml
+++ b/tools/jupyter_job/run_jupyter_job.xml
@@ -1,7 +1,7 @@
 <tool id="run_jupyter_job" name="Run long running jupyterlab script" hidden="true" version="0.0.1" profile="20.09">
     <description>inside a Docker container</description>
     <requirements>
-        <container type="docker">docker.io/anupkumar/docker-ml-jupyterlab:galaxy-integration-0.1</container>
+        <container type="docker">docker.io/anupkumar/docker-ml-jupyterlab:galaxy-integration-cpu-0.1</container>
     </requirements>
     <command detect_errors="aggressive"><![CDATA[
 	    python '${__tool_directory__}/main.py'


### PR DESCRIPTION
This PR uses a CPU-based, smaller docker container (uncompressed size ~12 GBs, compressed only ~ 5 GB) that excludes packages for setting up GPU computations. Currently, it takes a lot of time for running run_jupyter_job tool (over 3 hours) which runs within minutes inside a notebook. Using this smaller docker container, I would like to test if the size of the container is responsible for slow execution. Moreover, this tool already runs on CPU, therefore it makes less sense to let it download a large docker container (GPU container anupkumar/docker-ml-jupyterlab:galaxy-integration-0.1 is over 20 GBs).

The new container already runs the existing notebooks including both the use cases mentioned in https://training.galaxyproject.org/training-material/topics/statistics/tutorials/gpu_jupyter_lab/tutorial.html

Thanks!