### PR TITLE
Update PharmCAT to 1.8

### DIFF
--- a/tools/pharmcat/pharmcat.xml
+++ b/tools/pharmcat/pharmcat.xml
@@ -288,7 +288,6 @@ chr7      99665212       rs10264272      C         T         .         PASS     
 
 **Outputs**
 
-
 **NamedAlleleMatcher output:** 
 
 The NamedAlleleMatcher component generates both HTML and JSON files with detailed information about how data in the sample VCF matches up with haplotype definitions.

--- a/tools/pharmcat/pharmcat.xml
+++ b/tools/pharmcat/pharmcat.xml
@@ -1,13 +1,18 @@
 <tool id="pharmcat" name="pharmCAT" version="@WRAPPER_VERSION@+@VERSION_SUFFIX@" profile="20.01">
     <description>
-        Pharmacogenomics Clinical Annotation Tool
+        Pharmacogenomics Clinical Annotation Tool new and improved
     </description>
     <macros>
-        <token name="@WRAPPER_VERSION@">1.7.0</token>
+        <token name="@WRAPPER_VERSION@">1.8.0</token>
         <token name="@VERSION_SUFFIX@">galaxy0</token>
+        <xml name="bio_tools">
+            <xrefs>
+                <xref type="bio.tools">PharmCAT</xref>
+            </xrefs>
+        </xml>
     </macros>
     <requirements>
-        <container type="docker">pgkb/pharmcat:1.7.0</container>
+        <container type="docker">pgkb/pharmcat:@WRAPPER_VERSION@</container>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
     ## NAMECALLER FUNCTION
@@ -16,6 +21,9 @@
             java -cp /pharmcat/pharmcat.jar
             org.pharmgkb.pharmcat.haplotype.NamedAlleleMatcher
             -vcf input.vcf
+            #if $function_select.definitions:
+                -d $function_select.definitions
+            #end if
             -json output.json
             -html output.html
 
@@ -36,7 +44,6 @@
                 -o $function_select.outside_call
             #end if
             -f output.json
-
     ## REPORTER FUNCTION
         #else if $function_select.function == 'report':
             ln -s '$function_select.input' ./input.json &&
@@ -45,6 +52,9 @@
             -p input.json
             #if $function_select.title:
                 -t '$function_select.title'
+            #end if
+             #if $function_select.guidelines:
+                -g $function_select.guidelines
             #end if
             -j output.json
             -o output.html
@@ -59,6 +69,9 @@
             #if $function_select.outside_call:
                 -a $function_select.outside_call
             #end if
+            #if $function_select.definitions:
+                -na $function_select.definitions
+            #end if
             $function_select.json
             $function_select.phenojson
          #end if
@@ -72,17 +85,15 @@
                 <option value="report">Only reporter</option>
             </param>
             <when value="all">
-                <param name="input" argument="-vcf" type="data" format="vcf" label="Input vcf file"
-                    help="Must be formatted in modified official VCF format as detailed here: https://github.com/PharmGKB/PharmCAT/wiki/VCF-Requirements"/>
-                <param name="outside_call" argument="-a" type="data" format="tsv,tabular" label="Gene call TSV file from an outside tool" optional="true"/>
-                <param name="json" argument="-j" type="boolean" truevalue="-j" falsevalue="" label="Output reporter JSON report"/>
-                <param name="phenojson" argument="-pj" type="boolean" truevalue="-pj" falsevalue="" label="Output phenotyper JSON report"/>
-                <!-- <param name="definitions" argument="-na" type="data" format="list" label="Alternative allele definitions" help="a directory containing allele definitions to use instead of the default packaged allele definitions"/> -->
+                    <param name="input" argument="-vcf" type="data" format="vcf" label="Input vcf file" help="Must be formatted in modified official VCF format as detailed here: https://github.com/PharmGKB/PharmCAT/wiki/VCF-Requirements"/>
+                    <param name="outside_call" argument="-a" type="data" format="tsv,tabular" label="Gene call TSV file from an outside tool" optional="true"/>
+                    <param name="json" argument="-j" type="boolean" truevalue="-j" falsevalue="" label="Output reporter JSON report"/>
+                    <param name="phenojson" argument="-pj" type="boolean" truevalue="-pj" falsevalue="" label="Output phenotyper JSON report"/>
+                    <param name="definitions" argument="-na" type="data" format="list" label="Alternative allele definitions" optional='true' help="a directory containing allele definitions to use instead of the default packaged allele definitions" /> 
             </when>
             <when value="name">
-                <param name="input" argument="-vcf" type="data" format="vcf" label="Input vcf file"
-                    help="Must be formatted in modified official VCF format as detailed here: https://github.com/PharmGKB/PharmCAT/wiki/VCF-Requirements"/>
-                <!-- <param name="definitions" argument="-d" type="data" format="list" label="Alternative allele definitions" help="a directory containing allele definitions to use instead of the default packaged allele definitions"/> -->
+                <param name="input" argument="-vcf" type="data" format="vcf" label="Input vcf file" help="Must be formatted in modified official VCF format as detailed here: https://github.com/PharmGKB/PharmCAT/wiki/VCF-Requirements"/>
+                <param name="definitions" argument="-d" type="data" format="list" label="Alternative allele definitions" optional='true' help="a directory containing allele definitions to use instead of the default packaged allele definitions"/>
             </when>
             <when value="pheno">
                 <conditional name="method">
@@ -91,8 +102,7 @@
                         <option value="named">Run from the output of the NamedAlleleMatcher</option>
                     </param>
                     <when value="vcf">
-                        <param name="input" argument="-vcf" type="data" format="vcf" label="Input vcf file"
-                            help="Must be formatted in modified official VCF format as detailed here: https://github.com/PharmGKB/PharmCAT/wiki/VCF-Requirements"/>
+                        <param name="input" argument="-vcf" type="data" format="vcf" label="Input vcf file" help="Must be formatted in modified official VCF format as detailed here: https://github.com/PharmGKB/PharmCAT/wiki/VCF-Requirements"/>
                     </when>
                     <when value="named">
                         <param name="input" argument="-c" type="data" format="json" label="Input json file" help="JSON output of the NamedAlleleCaller pharmcat function"/>
@@ -103,6 +113,7 @@
             <when value="report">
                 <param name="input" argument="-p" type="data" format="json" label="JSON call data output from Phenotyper pharmCAT function"/>
                 <param name="title" argument="-t" type="text" label="text to add to the report title" optional="true"/>
+                <param name="guidelines" argument="-g" type="data" format="list" label="Alternative dosing guidelines" optional='true' help="directory containing JSON files of dosing guidelines instead of the default packaged guidelines"/>
             </when>
         </conditional>
     </inputs>
@@ -132,39 +143,40 @@
             <filter>function_select['function'] == "report"</filter>
         </data>
     </outputs>
-    <tests>
+        <tests>
     <!-- ALL FUNCTION -->
         <test expect_num_outputs="3">
             <conditional name="function_select">
-                <param name="input" value="test.vcf" ftype="vcf" />
-                <param name="outside_call" value="test.tsv" ftype="tabular"/>
+                <param name="input" ftype="vcf" value="test.vcf"/>
+                <param name="outside_call" ftype="tabular" value="test.tsv"/>
                 <param name="json" value="-j"/>
                 <param name="phenojson" value="-pj"/>
             </conditional>
             <output name="all_out">
                 <assert_contents>
-                    <has_text text="rs9923231 reference"/>
-                    <has_text text="Very high risk of developing hearing loss if administered an aminoglycoside antibiotic."/>
-                    <has_text text="CPIC Allele Function, Phenotype and Recommendation"/>
+                    <has_text text="Possibly higher atomoxetine concentrations as compared to normal metabolizers but questionable clinical significance. Intermediate metabolizers with an activity score of 1 may be at an increased risk of discontinuation as compared to poor metabolizers."/>
+                    <has_text text="Start with normal starting dose (e.g., 2-3 mg/kg/day) and adjust doses of azathioprine based on disease-specific guidelines. Allow 2 weeks to reach steady-state after each dose adjustment (PMID 20354201, 11302950, 15606506)."/>
+                    <has_text text="Consider a 25% reduction of recommended starting dose. Utilize therapeutic drug monitoring to guide dose adjustments."/>
                 </assert_contents>
             </output>
             <output name="all_pheno" file="test_1.pheno.json" lines_diff="1"/>
-            <output name="all_out_json">
-                <assert_contents>
-                    <has_text text="Therapeutic range of 200 to 1000 ng/mL has been proposed (PMID 29493375)."/>
-                    <has_text text="Activity Score for CYP2D6"/>
-                    <has_text text="Implementation Consortium (CPIC) Guideline for CYP2D6 Genotype and Use of Ondansetron and Tropisetron"/>
-                </assert_contents>
+            <output name="all_out_json" file="test_1_all_out.json" lines_diff="2">
             </output>
         </test>
     <!-- NAMECALLER -->
         <test expect_num_outputs="2">
             <conditional name="function_select">
                 <param name="function" value="name"/>
-                <param name="input" value="test.vcf" ftype="vcf"/>
+                <param name="input" ftype="vcf" value="test.vcf"/>
             </conditional>
-            <output name="namer_html" file="test_2.html" lines_diff="4" ftype="html" />
-            <output name="namer_json" file="test_2.json" lines_diff="2" ftype="json" />
+            <output name="namer_html">
+                <assert_contents>
+                    <has_text text="Called *1 without g.94938719T>G, g.94938788C>T, g.94938800G>A, g.94941975G>A, g.94942243T>G, g.94942306C>T, g.94942308C>T, g.94947939G>T, g.94949145C>T, g.94949163del, g.94972183A>T, g.94981258C>T, g.94986136A>C, g.94986174G>C"/>
+                    <has_text text="ivacaftor non-responsive CFTR sequence/ivacaftor non-responsive CFTR sequence (78)"/>
+                    <has_text text="rs12979860 reference (C)/rs12979860 reference (C) (2)"/>
+                </assert_contents>
+            </output>
+            <output name="namer_json" file="test_2.json" lines_diff="2"/>
         </test>
     <!-- PHENOTYPER FROM VCF WITH OUTSIDE CALLER-->
         <test expect_num_outputs="1">
@@ -183,18 +195,18 @@
             <conditional name="function_select">
                 <param name="function" value="pheno"/>
                 <conditional name="method">
-                    <param name="pheno_function" value="named" />
-                    <param name="input" value="test_2.json" ftype="json" />
+                    <param name="pheno_function" value="named"/>
+                    <param name="input" value="test_2.json"/>
                 </conditional>
             </conditional>
-            <output name="pheno_json" file="test_4.json" lines_diff="34"/>
+            <output name="pheno_json" file="test_4.json" lines_diff="1"/>
         </test>
     <!-- REPORTER -->
         <test expect_num_outputs="2">
             <conditional name="function_select">
-                <param name="input" value="test_3.json" ftype="json"/>
                 <param name="function" value="report"/>
-                <param name="text" value="test text"/>
+                    <param name="input" value="test_3.json"/>
+                    <param name="text" value="test text"/>
             </conditional>
             <output name="report_json">
                 <assert_contents>
@@ -213,7 +225,81 @@
         </test>
     </tests>
     <help><![CDATA[
+
+    .. class:: infomark
+
+    **What it does**
+
         PharmCAT is a tool to extract all CPIC guideline gene variants from a genetic dataset (represented as a VCF file), interpret the variant alleles, and generate a report.
+
+---- 
+
+Inputs:
+=======
+
+    **VCF File:**
+
+    PharmCAT expects the incoming VCF files to follow the official VCF spec.
+
+    In addition, PharmCAT expects incoming VCF to have the following properties:
+
+    1.   Build version must be aligned to the **GRCh38 assembly** (aka b38, hg38, etc.).
+    2.   **Any position not in the input VCF is assumed to be a “no call”**. Missing positions will not be interpreted as reference. You must specify all positions in the input VCF that you want to be considered.
+    3.   Use a parsimonious, left aligned variant representation format.
+    4.   Have insertions and deletions normalized to the expected representation.
+    5.   The CHROM field must be in the format **chr##**.
+    6.   The QUAL and FILTER columns are **not interpreted**. It is left to the user to remove data not meeting quality criteria before passing it to PharmCAT.
+    7.   Should only have data for a **single sample**. If it's a multi-sample VCF file, **only the first sample is used**.
+
+    The Following table gives an example of a properly formated VCF file:
+
+========= ============== =============== ========= ========= ========= ========= ========= ========= =========
+#CHROM    POS            ID              REF       ALT       QUAL      FILTER    INFO      FORMAT    PharmCAT
+--------- -------------- --------------- --------- --------- --------- --------- --------- --------- ---------
+chr1      97078987       rs114096998     G         T         .         PASS      PX=DPYD   GT        0/0 
+--------- -------------- --------------- --------- --------- --------- --------- --------- --------- ---------
+chr1      97078993       rs148799944     C         G         .         PASS      PX=DPYD   GT        0/0
+--------- -------------- --------------- --------- --------- --------- --------- --------- --------- ---------
+chr7      99665212       rs10264272      C         T         .         PASS      PX=CYP3A5 GT        0/0
+========= ============== =============== ========= ========= ========= ========= ========= ========= =========
+
+---- 
+
+    **Outside Call Files:**
+
+    Typically, PharmCAT uses variant call data to match diplotypes used to find annotations. However, you can also give diplotypes to PharmCAT that were called by other tools. This is especially useful for genes that PharmCAT will not match like CYP2D6.
+
+    The outside call file format is a tab-separated file.
+
+    Each line starts with the HGNC gene symbol, then a tab, then the diplotype (e.g. 1/3). Lines starting with # will be ignored.
+
+    Here's an example of an outside call file:
+
+    ======= ==========================
+    CYP2D6  1/3
+    ------- --------------------------
+    G6PD    B (wildtype)/B (wildtype)
+    ------- --------------------------
+    MT-RNR1 1555A>G
+    ======= ==========================
+
+
+----
+
+**Outputs**
+
+**NamedAlleleMatcher output:** 
+
+The NamedAlleleMatcher component generates both HTML and JSON files with detailed information about how data in the sample VCF matches up with haplotype definitions.
+
+**Phenotyper output:**
+
+The Phenotyper component takes data from the NamedAlleleMatcher and combines it with outside call data to assign function and metabolizer values.
+
+**Reporter output:**
+
+The Reporter component takes data from the Phenotyper and matches phenotypes to information found in CPIC guideline data. This data is visible in an HTML report and also in a JSON file for machine parsing.
+
     ]]></help>
     <citations>
         <citation type="doi" >10.1002/cpt.928</citation>

--- a/tools/pharmcat/pharmcat.xml
+++ b/tools/pharmcat/pharmcat.xml
@@ -288,6 +288,7 @@ chr7      99665212       rs10264272      C         T         .         PASS     
 
 **Outputs**
 
+
 **NamedAlleleMatcher output:** 
 
 The NamedAlleleMatcher component generates both HTML and JSON files with detailed information about how data in the sample VCF matches up with haplotype definitions.


### PR DESCRIPTION
Updating PharmCAT to the newest version 1.8. Added significant content to the help section and added support for outside call files, alternative allele definitions, and alternative dosing guidelines for expanded options. 

**How to test the Changes?**

- Updated planemo tests to function with changes made in the 1.8 code.
