### PR TITLE
[Split file on column] adapt tool to work on unsorted columns, add test cases

### DIFF
--- a/tools/text_processing/split_file_on_column/split_file_on_column.xml
+++ b/tools/text_processing/split_file_on_column/split_file_on_column.xml
@@ -1,4 +1,4 @@
-<tool id="tp_split_on_column" name="Split by group" version="0.5">
+<tool id="tp_split_on_column" name="Split by group" version="0.6">
     <requirements>
         <requirement type="package" version="5.0.1">gawk</requirement>
     </requirements>
@@ -6,9 +6,9 @@
 <![CDATA[
     mkdir tmp_out &&
     #if $include_header
-        awk -F '\t' 'NR==1{hdr=$0;next}f!="tmp_out/"\$$column".$infile.ext"{if(f) close(f); f="tmp_out/"\$$column".$infile.ext";print hdr>f} {print >> f}' $infile
+        awk -F '\t' 'NR==1{hdr=$0;next}f!="tmp_out/"\$$column".$infile.ext"{if(f) close(f); f="tmp_out/"\$$column".$infile.ext"}; {if (!seen[f]++) print hdr>f; print >> f}' $infile
     #else
-        awk -F'\t' '{print > "tmp_out/"\$$column".$infile.ext" }' '$infile'
+        awk -F'\t' '{print >> "tmp_out/"\$$column".$infile.ext" }' '$infile'
     #end if
 ]]>
     </command>
@@ -76,6 +76,43 @@
                 <element name="2">
                     <assert_contents>
                         <has_text_matching expression="chr7\t56761\t56781\tcluster\t2" />
+                    </assert_contents>
+                </element>
+            </output_collection>
+        </test>
+        <test><!-- test with unsorted column, no header -->
+            <param name="infile" value="5cols-unsorted.tabular" ftype="tabular" />
+            <param name="column" value="5" />
+            <param name="include_header" value="false"/>
+            <output_collection name="split_output" type="list">
+                <element name="1">
+                    <assert_contents>
+                        <has_n_lines n="3" />
+                    </assert_contents>
+                </element>
+                <element name="2">
+                    <assert_contents>
+                        <has_n_lines n="2" />
+                    </assert_contents>
+                </element>
+            </output_collection>
+        </test>
+        <test><!-- test with unsorted column, with header -->
+            <param name="infile" value="5cols-unsorted-with-header.tabular" ftype="tabular" />
+            <param name="column" value="5" />
+            <param name="include_header" value="true"/>
+            <output_collection name="split_output" type="list">
+                <element name="1">
+                    <assert_contents>
+                        <has_n_lines n="4" />
+                        <has_line_matching expression="Column1\tColumn2\tColumn3\tColumn4\tColumn5" />
+
+                    </assert_contents>
+                </element>
+                <element name="2">
+                    <assert_contents>
+                        <has_n_lines n="3" />
+                        <has_line_matching expression="Column1\tColumn2\tColumn3\tColumn4\tColumn5" />
                     </assert_contents>
                 </element>
             </output_collection>

--- a/tools/text_processing/split_file_on_column/split_file_on_column.xml
+++ b/tools/text_processing/split_file_on_column/split_file_on_column.xml
@@ -1,6 +1,6 @@
 <tool id="tp_split_on_column" name="Split by group" version="0.6">
     <requirements>
-        <requirement type="package" version="5.0.1">gawk</requirement>
+        <requirement type="package" version="5.1.0">gawk</requirement>
     </requirements>
     <command>
 <![CDATA[

--- a/tools/text_processing/split_file_on_column/split_file_on_column.xml
+++ b/tools/text_processing/split_file_on_column/split_file_on_column.xml
@@ -149,7 +149,7 @@ Splitting this file on column 1::
     chr4 60 80
 
 
-will produce a collectiion with 4 elements::
+will produce a collection with 3 elements::
 
     chr1 10 20
     chr1 30 40

--- a/tools/text_processing/split_file_on_column/test-data/5cols-unsorted-with-header.tabular
+++ b/tools/text_processing/split_file_on_column/test-data/5cols-unsorted-with-header.tabular
@@ -1,0 +1,6 @@
+Column1	Column2	Column3	Column4	Column5
+chr7	56632	56652	cluster	1
+chr7	56736	56756	cluster	2
+chr7	56761	56781	cluster	1
+chr7	56772	56792	cluster	1
+chr7	56775	56795	cluster	2

--- a/tools/text_processing/split_file_on_column/test-data/5cols-unsorted.tabular
+++ b/tools/text_processing/split_file_on_column/test-data/5cols-unsorted.tabular
@@ -1,0 +1,5 @@
+chr7	56632	56652	cluster	1
+chr7	56736	56756	cluster	2
+chr7	56761	56781	cluster	1
+chr7	56772	56792	cluster	1
+chr7	56775	56795	cluster	2


### PR DESCRIPTION
Working on a tutorial on data manipulation, and noticed this tool only works properly if the column was sorted (data was missing if unsorted, only the last cluster of consecutive rows with the certain value was present in the final file)

This adapts the tool to work for unsorted columns as well, and adds test cases.

