### PR TITLE
Fix issue with param loading and tool tests

### DIFF
--- a/tools/sklearn/main_macros.xml
+++ b/tools/sklearn/main_macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@VERSION@">1.0.8.3</token>
+    <token name="@VERSION@">1.0.8.4</token>
 
     <xml name="python_requirements">
         <requirements>

--- a/tools/sklearn/search_model_validation.xml
+++ b/tools/sklearn/search_model_validation.xml
@@ -9,7 +9,7 @@
             <param name="infile_params" type="data" format="tabular" optional="true" label="Choose the dataset containing parameter names" help="This dataset could be the output of `get_params` in the `Estimator Attributes` tool."/>
             <repeat name="param_set" min="1" max="30" title="Parameter settings for search:">
                 <param name="sp_name" type="select" optional="true" label="Choose a parameter name (with current value)">
-                    <options from_dataset="infile_params" startswith="@">
+                    <options from_dataset="infile_params" startswith="'@'">
                     <column name="name" index="2"/>
                     <column name="value" index="1"/>
                     <filter type="unique_value" name="unique_param" column="1"/>

--- a/tools/sklearn/search_model_validation.xml
+++ b/tools/sklearn/search_model_validation.xml
@@ -9,7 +9,7 @@
             <param name="infile_params" type="data" format="tabular" optional="true" label="Choose the dataset containing parameter names" help="This dataset could be the output of `get_params` in the `Estimator Attributes` tool."/>
             <repeat name="param_set" min="1" max="30" title="Parameter settings for search:">
                 <param name="sp_name" type="select" optional="true" label="Choose a parameter name (with current value)">
-                    <options from_dataset="infile_params" startswith="'@'">
+                    <options from_dataset="infile_params">
                     <column name="name" index="2"/>
                     <column name="value" index="1"/>
                     <filter type="unique_value" name="unique_param" column="1"/>


### PR DESCRIPTION
This PR fixes the issue: https://github.com/bgruening/galaxytools/issues/1231

Because of the unquoted @ symbol, most of the parameters of the selected estimator fail to load from a tubular file containing all parameters of the estimator.

![params](https://user-images.githubusercontent.com/3022518/183875240-15861782-144a-4502-acf4-01a38a4b78cc.png)

Without the quoted @, the dropdown fails to load all the params, shown below:

![params_fail](https://user-images.githubusercontent.com/3022518/183875756-1553d883-168c-4117-ac6a-3252e2449f4b.png)

EDIT: Removing @ for filtering estimator params fixes the issue

