### PR TITLE
Updating tools/flye from version 2.9 to 2.9.1

### DIFF
--- a/tools/flye/flye.xml
+++ b/tools/flye/flye.xml
@@ -39,6 +39,7 @@
         #end if
         $meta
         $scaffold
+        $no_alt_contigs
     ]]></command>
     <inputs>
         <param name="inputs" type="data" format="fasta,fasta.gz,fastq,fastq.gz,fastqsanger.gz,fastqsanger" multiple="true" label="Input reads" />
@@ -97,6 +98,7 @@
             </when>
             <when value="false" />
         </conditional>
+        <param argument="--no-alt-contigs" type="boolean" truevalue="--no-alt-contigs" falsevalue="" checked="false" label="Remove all non-primary contigs from the assembly"/>
         <param name="generate_log" type="boolean" truevalue="true" falsevalue="false" checked="false" label="Generate a log file"/>
     </inputs>
     <outputs>
@@ -318,6 +320,33 @@
             <output name="consensus" ftype="fasta">
                 <assert_contents>
                     <has_size value="427129" delta="100"/>
+               </assert_contents>
+            </output>
+        </test>
+        <!--Test 09: test not-alt-contigs parameter w-->
+        <test expect_num_outputs="4">
+            <param name="inputs" ftype="fasta.gz" value="nanopore.fasta.gz"/>
+            <param name="mode" value="--nano-raw"/>
+            <param name="iterations" value="0"/>
+            <param name="no_alt_contigs" value="true"/>
+            <output name="assembly_info" ftype="tabular">
+                <assert_contents>
+                    <has_size value="151" delta="100"/>
+               </assert_contents>
+            </output>
+            <output name="assembly_graph" ftype="graph_dot">
+                <assert_contents>
+                    <has_size value="217" delta="100"/>
+               </assert_contents>
+            </output>
+            <output name="assembly_gfa" ftype="txt">
+                <assert_contents>
+                    <has_size value="5510" delta="100"/>
+               </assert_contents>
+            </output>
+            <output name="consensus" ftype="fasta">
+                <assert_contents>
+                    <has_size value="5123" delta="100"/>
                </assert_contents>
             </output>
         </test>

--- a/tools/flye/flye.xml
+++ b/tools/flye/flye.xml
@@ -341,7 +341,7 @@
             </output>
             <output name="assembly_gfa" ftype="txt">
                 <assert_contents>
-                    <has_size value="5510" delta="100"/>
+                    <has_size value="5110" delta="100"/>
                </assert_contents>
             </output>
             <output name="consensus" ftype="fasta">

--- a/tools/flye/macros.xml
+++ b/tools/flye/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.9</token>
+    <token name="@TOOL_VERSION@">2.9.1</token>
     <token name="@SUFFIX_VERSION@">0</token>
     <xml name="requirements">
         <requirements>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/flye**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/flye from version 2.9 to 2.9.1.

**Project home page:** https://github.com/fenderglass/Flye/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).