### PR TITLE
Updating tools/rna_tools/ribotaper from version 1.3.1a to 1.3.1

### DIFF
--- a/tools/rna_tools/ribotaper/macros.xml
+++ b/tools/rna_tools/ribotaper/macros.xml
@@ -1,11 +1,11 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.3.1a</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@TOOL_VERSION@">1.3.1</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">ribotaper</requirement>
-            <requirement type="package" version="9.1">coreutils</requirement>
-            <requirement type="package" version="9.54.0">ghostscript</requirement>
+            <requirement type="package" version="9.5">coreutils</requirement>
+            <requirement type="package" version="10.04.0">ghostscript</requirement>
 
         </requirements>
     </xml>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/rna_tools/ribotaper**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/rna_tools/ribotaper from version 1.3.1a to 1.3.1.

**Project home page:** https://ohlerlab.mdc-berlin.de/software/RiboTaper_126

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).