### PR TITLE
Updating tools/chipseeker from version 1.32.0 to 1.38.0

### DIFF
--- a/tools/chipseeker/chipseeker.xml
+++ b/tools/chipseeker/chipseeker.xml
@@ -1,7 +1,7 @@
 <tool id="chipseeker" name="ChIPseeker" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>for ChIP peak annotation and visualization</description>
     <macros>
-        <token name="@TOOL_VERSION@">1.36.0</token>
+        <token name="@TOOL_VERSION@">1.38.0</token>
         <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>

--- a/tools/chipseeker/chipseeker.xml
+++ b/tools/chipseeker/chipseeker.xml
@@ -1,7 +1,7 @@
 <tool id="chipseeker" name="ChIPseeker" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>for ChIP peak annotation and visualization</description>
     <macros>
-        <token name="@TOOL_VERSION@">1.34.0</token>
+        <token name="@TOOL_VERSION@">1.36.0</token>
         <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>

--- a/tools/chipseeker/chipseeker.xml
+++ b/tools/chipseeker/chipseeker.xml
@@ -1,12 +1,12 @@
 <tool id="chipseeker" name="ChIPseeker" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>for ChIP peak annotation and visualization</description>
     <macros>
-        <token name="@TOOL_VERSION@">1.32.0</token>
+        <token name="@TOOL_VERSION@">1.34.0</token>
         <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">bioconductor-chipseeker</requirement>
-        <requirement type="package" version="1.6.6">r-optparse</requirement>
+        <requirement type="package" version="1.7.3">r-optparse</requirement>
     </requirements>
     <version_command><![CDATA[
 echo $(R --version | grep version | grep -v GNU)", ChIPseeker version" $(R --vanilla --slave -e "library(ChIPseeker); cat(sessionInfo()\$otherPkgs\$ChIPseeker\$Version)" 2> /dev/null | grep -v -i "WARNING: ")", optparse version" $(R --vanilla --slave -e "library(optparse); cat(sessionInfo()\$otherPkgs\$optparse\$Version)" 2> /dev/null | grep -v -i "WARNING: ")


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/chipseeker**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/chipseeker from version 1.32.0 to 1.34.0.

**Project home page:** https://bioconductor.org/packages/release/bioc/html/ChIPseeker.html

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).