### PR TITLE
Use legacy URL for Uniprot 

### DIFF
--- a/tools/uniprot_rest_interface/uniprot.py
+++ b/tools/uniprot_rest_interface/uniprot.py
@@ -19,7 +19,7 @@ from requests.packages.urllib3.util.retry import Retry
 
 
 DEFAULT_TIMEOUT = 5  # seconds
-URL = 'https://www.uniprot.org/'
+URL = 'https://legacy.uniprot.org/'
 
 retry_strategy = Retry(
     total=5,

--- a/tools/uniprot_rest_interface/uniprot.xml
+++ b/tools/uniprot_rest_interface/uniprot.xml
@@ -1,4 +1,4 @@
-<tool id="uniprot" name="UniProt" version="0.3">
+<tool id="uniprot" name="UniProt" version="0.4">
     <description>ID mapping and retrieval</description>
     <macros>
          <import>macros.xml</import>


### PR DESCRIPTION
This allows the tool to keep being used until new code is written to utilize the new API, which requires submitting, polling, and fetching the results of an ID mapping job.