### PR TITLE
Updating tools/rna_tools/locarna from version 1.9.2.3 to 2.0.0

### DIFF
--- a/tools/rna_tools/locarna/macros.xml
+++ b/tools/rna_tools/locarna/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.9.2.3</token>
+    <token name="@TOOL_VERSION@">2.0.0</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">21.09</token>
 

--- a/tools/rna_tools/locarna/macros.xml
+++ b/tools/rna_tools/locarna/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.0.0</token>
+    <token name="@TOOL_VERSION@">2.0.1</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">21.09</token>
 


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/rna_tools/locarna**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/rna_tools/locarna from version 1.9.2.3 to 2.0.0.

**Project home page:** http://www.bioinf.uni-freiburg.de/Software/LocARNA

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).