### PR TITLE
add `--discover` to manipulation option for gfastats

### DIFF
--- a/tools/gfastats/gfastats.xml
+++ b/tools/gfastats/gfastats.xml
@@ -33,6 +33,7 @@
             #if $mode_condition.homopolymer_compress
                 --homopolymer-compress $mode_condition.homopolymer_compress
             #end if
+            $mode_condition.discover_paths
             -o dataset.$mode_condition.output_condition.out_format
             #if $mode_condition.output_condition.out_format == 'fasta'
                 #if $mode_condition.output_condition.line_length
@@ -129,6 +130,8 @@
                     <when value="fastq.gz"/>
                     <when value="gfa"/>
                     <when value="gfa.gz"/>
+                    <param argument="--discover-paths" type="boolean" truevalue="--discover-paths" falsevalue="" checked="false" label="Generates the initial set of paths" help="In the graph space an assembly 
+                    is a collection of segment and edges/gaps between these segments. A path defines a potential walk through the segments and edges/gaps that corresponds to a hypothesis of the actual linear sequence" />
                 </conditional>
                 <param argument="--sort" type="select" label="Sort sequences" help="Specify how to sort the sequences. Ascending/descending used the sequence/path header.">
                     <option value="" selected="true">Disabled</option>

--- a/tools/gfastats/gfastats.xml
+++ b/tools/gfastats/gfastats.xml
@@ -130,9 +130,9 @@
                     <when value="fastq.gz"/>
                     <when value="gfa"/>
                     <when value="gfa.gz"/>
-                    <param argument="--discover-paths" type="boolean" truevalue="--discover-paths" falsevalue="" checked="false" label="Generates the initial set of paths" help="In the graph space an assembly 
+		</conditional>
+                <param argument="--discover-paths" type="boolean" truevalue="--discover-paths" falsevalue="" checked="false" label="Generates the initial set of paths" help="In the graph space an assembly 
                     is a collection of segment and edges/gaps between these segments. A path defines a potential walk through the segments and edges/gaps that corresponds to a hypothesis of the actual linear sequence" />
-                </conditional>
                 <param argument="--sort" type="select" label="Sort sequences" help="Specify how to sort the sequences. Ascending/descending used the sequence/path header.">
                     <option value="" selected="true">Disabled</option>
                     <option value="ascending">Ascending</option>

--- a/tools/gfastats/macros.xml
+++ b/tools/gfastats/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">1.3.5</token>
-    <token name="@SUFFIX_VERSION@">0</token>
+    <token name="@SUFFIX_VERSION@">1</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">gfastats</requirement>


### PR DESCRIPTION
hello! 👋🏼 

gfastats manipulation options were failing on hifiasm-generated GFA files due to those commands needing `--discover-paths`, which was not exposed as an option in the manipulation option of the previous tool wrapper. I have added this in