### PR TITLE
fix owner for CI deploy step

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -349,7 +349,7 @@ jobs:
   deploy:
     name: Deploy
     needs: [setup, lint, flake8, lintr, combine_outputs]
-    if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) && github.repository_owner == 'galaxyproject' }}
+    if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) && github.repository_owner == 'bgruening' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
The following PR have not been deployed due to this bug (introduced here https://github.com/bgruening/galaxytools/pull/1264)

https://github.com/bgruening/galaxytools/pull/1269
https://github.com/bgruening/galaxytools/pull/1266
https://github.com/bgruening/galaxytools/pull/1263

Will bump the affected tools after this is merged

