### PR TITLE
Updating tools/flye from version 2.9.1 to 2.9.4

### DIFF
--- a/tools/flye/macros.xml
+++ b/tools/flye/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.9.3</token>
+    <token name="@TOOL_VERSION@">2.9.4</token>
     <token name="@SUFFIX_VERSION@">0</token>
     <xml name="requirements">
         <requirements>

--- a/tools/flye/macros.xml
+++ b/tools/flye/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.9.1</token>
+    <token name="@TOOL_VERSION@">2.9.2</token>
     <token name="@SUFFIX_VERSION@">0</token>
     <xml name="requirements">
         <requirements>

--- a/tools/flye/macros.xml
+++ b/tools/flye/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.9.2</token>
+    <token name="@TOOL_VERSION@">2.9.3</token>
     <token name="@SUFFIX_VERSION@">0</token>
     <xml name="requirements">
         <requirements>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/flye**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/flye from version 2.9.1 to 2.9.2.

**Project home page:** https://github.com/fenderglass/Flye/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).