### PR TITLE
Updating tools/mafft from version 7.508 to 7.525

### DIFF
--- a/tools/mafft/macros.xml
+++ b/tools/mafft/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
     <token name="@VERSION@">0</token>
-    <token name="@TOOL_VERSION@">7.520</token>
+    <token name="@TOOL_VERSION@">7.525</token>
     <xml name="requirements">
       <requirements>
           <requirement type="package" version="@TOOL_VERSION@">mafft</requirement>

--- a/tools/mafft/macros.xml
+++ b/tools/mafft/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
     <token name="@VERSION@">0</token>
-    <token name="@TOOL_VERSION@">7.508</token>
+    <token name="@TOOL_VERSION@">7.520</token>
     <xml name="requirements">
       <requirements>
           <requirement type="package" version="@TOOL_VERSION@">mafft</requirement>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/mafft**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/mafft from version 7.508 to 7.520.

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).