### PR TITLE
Updating tools/trim_galore from version 0.6.7 to 0.6.10

### DIFF
--- a/tools/trim_galore/macros.xml
+++ b/tools/trim_galore/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.6.7</token>
+    <token name="@TOOL_VERSION@">0.6.10</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/trim_galore**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/trim_galore from version 0.6.7 to 0.6.10.

**Project home page:** http://www.bioinformatics.babraham.ac.uk/projects/trim_galore

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).