### PR TITLE
Add fastqsanger acceptance for racon

### DIFF
--- a/tools/racon/racon.xml
+++ b/tools/racon/racon.xml
@@ -53,7 +53,7 @@
             > racon_polished_consensus.fa  
     ]]></command>
     <inputs>
-        <param type="data" name="reads" format="fasta,fasta.gz,fastq,fastq.gz" label="Sequences" help="input file in FASTA/FASTQ format (can be compressed with gzip) containing sequences used for correction"/>
+        <param type="data" name="reads" format="fasta,fasta.gz,fastq,fastq.gz,fastqsanger,fastqsanger.gz" label="Sequences" help="input file in FASTA/FASTQ format (can be compressed with gzip) containing sequences used for correction"/>
         <param type="data" name="overlaps" format="paf,sam,tabular" label="Overlaps" help="input file in MHAP/PAF/SAM format (can be compressed with gzip) containing overlaps between sequences and target sequences"/>
         <param type="data" name="corrected_reads" format="fasta,fasta.gz,fastq,fastq.gz" label="Target sequences" help="Input file in FASTA/FASTQ format (can be compressed with gzip) containing sequences which will be corrected"/>
         <param argument="--include-unpolished" type="boolean" truevalue="-u" falsevalue="" label="Include unpolished" help="Output unpolished target sequences" />


### PR DESCRIPTION
Discovered by @shiltemann

(I feel like `fastq` and `fastq.gz` should be sufficient to accept both of these but I guess not?)