### PR TITLE
Updating tools/salmon from version 1.10.1 to 1.10.2

### DIFF
--- a/tools/salmon/macros.xml
+++ b/tools/salmon/macros.xml
@@ -1,17 +1,17 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.10.1</token>
+    <token name="@TOOL_VERSION@">1.10.2</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@IDX_VERSION@">q7</token>
     <token name="@PROFILE_VERSION@">20.01</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">salmon</requirement>
-            <requirement type="package" version="1.3">seqtk</requirement>
-            <requirement type="package" version="1.16.1">samtools</requirement>
-            <requirement type="package" version="0.2.0">vpolo</requirement>
-            <requirement type="package" version="1.5.2">pandas</requirement>
-            <requirement type="package" version="3.0.0">graphviz</requirement>
-            <requirement type="package" version="1.9.3">scipy</requirement>
+            <requirement type="package" version="1.4">seqtk</requirement>
+            <requirement type="package" version="1.17">samtools</requirement>
+            <requirement type="package" version="0.3.0">vpolo</requirement>
+            <requirement type="package" version="2.0.3">pandas</requirement>
+            <requirement type="package" version="8.0.5">graphviz</requirement>
+            <requirement type="package" version="1.11.1">scipy</requirement>
         </requirements>
     </xml>
     <xml name="orient">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/salmon**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/salmon from version 1.10.1 to 1.10.2.

**Project home page:** https://github.com/COMBINE-lab/salmon/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).