### PR TITLE
Cmsearch: added missing args to command

### DIFF
--- a/tools/rna_tools/infernal/cmsearch.xml
+++ b/tools/rna_tools/infernal/cmsearch.xml
@@ -39,6 +39,12 @@
             #if $A:
                 $A '$multiple_alignment_output'
             #end if
+            #if $noali:
+            	$noali
+            #end if
+            #if $verbose:
+            	$verbose
+            #end if
             #if str($inclusion_thresholds_opts.inclusion_thresholds_selector) == "--incE":
                 --incE $inclusion_thresholds_opts.incE
             #elif str($inclusion_thresholds_opts.inclusion_thresholds_selector) == "--incT":


### PR DESCRIPTION
`--noali ` and `--verbose` arguments did not work, because they were missing in the command.