### PR TITLE
Output CSVLogger callback to a tabular file

### DIFF
--- a/tools/sklearn/keras_macros.xml
+++ b/tools/sklearn/keras_macros.xml
@@ -725,7 +725,7 @@
           <!--option value="ModelCheckpoint">ModelCheckpoint - Save the model after every epoch</option>-->
           <option value="TerminateOnNaN">TerminateOnNaN -- Terminates training when a NaN loss is encountered.</option>
           <option value="ReduceLROnPlateau">ReduceLROnPlateau -- Reduce learning rate when a metric has stopped improving</option>
-          <!--<option value="CSVLogger">CSVLogger - Streams epoch results to a csv file</option>-->
+          <option value="CSVLogger">CSVLogger -- Streams epoch results to a csv file</option>
         </param>
         <when value="None" />
         <when value="EarlyStopping">
@@ -778,7 +778,7 @@
             <param argument="min_lr" type="float" value="0" help="Lower bound on the learning rate." />
           </expand>
         </when>
-        <!--<when value="CSVLogger" />-->
+        <when value="CSVLogger" />
       </conditional>
     </repeat>
   </xml>

--- a/tools/sklearn/keras_macros.xml
+++ b/tools/sklearn/keras_macros.xml
@@ -725,7 +725,7 @@
           <!--option value="ModelCheckpoint">ModelCheckpoint - Save the model after every epoch</option>-->
           <option value="TerminateOnNaN">TerminateOnNaN -- Terminates training when a NaN loss is encountered.</option>
           <option value="ReduceLROnPlateau">ReduceLROnPlateau -- Reduce learning rate when a metric has stopped improving</option>
-          <option value="CSVLogger">CSVLogger -- Streams epoch results to a csv file</option>
+          <!--<option value="CSVLogger">CSVLogger - Streams epoch results to a csv file</option>-->
         </param>
         <when value="None" />
         <when value="EarlyStopping">
@@ -778,7 +778,7 @@
             <param argument="min_lr" type="float" value="0" help="Lower bound on the learning rate." />
           </expand>
         </when>
-        <when value="CSVLogger" />
+        <!--<when value="CSVLogger" />-->
       </conditional>
     </repeat>
   </xml>

--- a/tools/sklearn/keras_train_and_eval.py
+++ b/tools/sklearn/keras_train_and_eval.py
@@ -188,7 +188,7 @@ def main(
     infile1,
     infile2,
     outfile_result,
-    outfile_history,
+    outfile_history=None,
     outfile_object=None,
     outfile_y_true=None,
     outfile_y_preds=None,
@@ -216,7 +216,7 @@ def main(
     outfile_result : str
         File path to save the results, either cv_results or test result.
 
-    outfile_history : str
+    outfile_history : str, optional
         File path to save the training history.
 
     outfile_object : str, optional
@@ -455,11 +455,15 @@ def main(
             history = estimator.fit(X_train, y_train, validation_data=(X_test, y_test))
     else:
         history = estimator.fit(X_train, y_train)
-    hist_df = pd.DataFrame(history.history)
-    hist_df["epoch"] = np.arange(1, estimator_params["epochs"]+1)
-    epo_col = hist_df.pop('epoch')
-    hist_df.insert(0, 'epoch', epo_col)
-    hist_df.to_csv(path_or_buf=outfile_history, sep="\t", header=True, index=False)
+    if "callbacks" in estimator_params:
+        for cb in estimator_params["callbacks"]:
+             if cb["callback_selection"]["callback_type"] == "CSVLogger":
+                 hist_df = pd.DataFrame(history.history)
+                 hist_df["epoch"] = np.arange(1, estimator_params["epochs"]+1)
+                 epo_col = hist_df.pop('epoch')
+                 hist_df.insert(0, 'epoch', epo_col)
+                 hist_df.to_csv(path_or_buf=outfile_history, sep="\t", header=True, index=False)
+                 break
     if isinstance(estimator, KerasGBatchClassifier):
         scores = {}
         steps = estimator.prediction_steps

--- a/tools/sklearn/keras_train_and_eval.py
+++ b/tools/sklearn/keras_train_and_eval.py
@@ -553,7 +553,7 @@ if __name__ == "__main__":
         args.infile1,
         args.infile2,
         args.outfile_result,
-        args.outfile_history,
+        outfile_history=args.outfile_history,
         outfile_object=args.outfile_object,
         outfile_y_true=args.outfile_y_true,
         outfile_y_preds=args.outfile_y_preds,

--- a/tools/sklearn/keras_train_and_eval.py
+++ b/tools/sklearn/keras_train_and_eval.py
@@ -456,6 +456,9 @@ def main(
     else:
         history = estimator.fit(X_train, y_train)
     hist_df = pd.DataFrame(history.history)
+    hist_df["epoch"] = np.arange(1, estimator_params["epochs"]+1)
+    epo_col = hist_df.pop('epoch')
+    hist_df.insert(0, 'epoch', epo_col)
     hist_df.to_csv(path_or_buf=outfile_history, sep="\t", header=True, index=False)
     if isinstance(estimator, KerasGBatchClassifier):
         scores = {}

--- a/tools/sklearn/keras_train_and_eval.py
+++ b/tools/sklearn/keras_train_and_eval.py
@@ -188,6 +188,7 @@ def main(
     infile1,
     infile2,
     outfile_result,
+    outfile_history,
     outfile_object=None,
     outfile_y_true=None,
     outfile_y_preds=None,
@@ -214,6 +215,9 @@ def main(
 
     outfile_result : str
         File path to save the results, either cv_results or test result.
+
+    outfile_history : str
+        File path to save the training history.
 
     outfile_object : str, optional
         File path to save searchCV object.
@@ -253,9 +257,7 @@ def main(
     swapping = params["experiment_schemes"]["hyperparams_swapping"]
     swap_params = _eval_swap_params(swapping)
     estimator.set_params(**swap_params)
-
     estimator_params = estimator.get_params()
-
     # store read dataframe object
     loaded_df = {}
 
@@ -448,12 +450,13 @@ def main(
     # train and eval
     if hasattr(estimator, "config") and hasattr(estimator, "model_type"):
         if exp_scheme == "train_val_test":
-            estimator.fit(X_train, y_train, validation_data=(X_val, y_val))
+            history = estimator.fit(X_train, y_train, validation_data=(X_val, y_val))
         else:
-            estimator.fit(X_train, y_train, validation_data=(X_test, y_test))
+            history = estimator.fit(X_train, y_train, validation_data=(X_test, y_test))
     else:
-        estimator.fit(X_train, y_train)
-
+        history = estimator.fit(X_train, y_train)
+    hist_df = pd.DataFrame(history.history)
+    hist_df.to_csv(path_or_buf=outfile_history, sep="\t", header=True, index=False)
     if isinstance(estimator, KerasGBatchClassifier):
         scores = {}
         steps = estimator.prediction_steps
@@ -526,6 +529,7 @@ if __name__ == "__main__":
     aparser.add_argument("-X", "--infile1", dest="infile1")
     aparser.add_argument("-y", "--infile2", dest="infile2")
     aparser.add_argument("-O", "--outfile_result", dest="outfile_result")
+    aparser.add_argument("-hi", "--outfile_history", dest="outfile_history")
     aparser.add_argument("-o", "--outfile_object", dest="outfile_object")
     aparser.add_argument("-l", "--outfile_y_true", dest="outfile_y_true")
     aparser.add_argument("-p", "--outfile_y_preds", dest="outfile_y_preds")
@@ -542,6 +546,7 @@ if __name__ == "__main__":
         args.infile1,
         args.infile2,
         args.outfile_result,
+        args.outfile_history,
         outfile_object=args.outfile_object,
         outfile_y_true=args.outfile_y_true,
         outfile_y_preds=args.outfile_y_preds,

--- a/tools/sklearn/keras_train_and_eval.py
+++ b/tools/sklearn/keras_train_and_eval.py
@@ -457,13 +457,13 @@ def main(
         history = estimator.fit(X_train, y_train)
     if "callbacks" in estimator_params:
         for cb in estimator_params["callbacks"]:
-             if cb["callback_selection"]["callback_type"] == "CSVLogger":
-                 hist_df = pd.DataFrame(history.history)
-                 hist_df["epoch"] = np.arange(1, estimator_params["epochs"]+1)
-                 epo_col = hist_df.pop('epoch')
-                 hist_df.insert(0, 'epoch', epo_col)
-                 hist_df.to_csv(path_or_buf=outfile_history, sep="\t", header=True, index=False)
-                 break
+            if cb["callback_selection"]["callback_type"] == "CSVLogger":
+                hist_df = pd.DataFrame(history.history)
+                hist_df["epoch"] = np.arange(1, estimator_params["epochs"] + 1)
+                epo_col = hist_df.pop('epoch')
+                hist_df.insert(0, 'epoch', epo_col)
+                hist_df.to_csv(path_or_buf=outfile_history, sep="\t", header=True, index=False)
+                break
     if isinstance(estimator, KerasGBatchClassifier):
         scores = {}
         steps = estimator.prediction_steps

--- a/tools/sklearn/keras_train_and_eval.xml
+++ b/tools/sklearn/keras_train_and_eval.xml
@@ -29,6 +29,7 @@
             #end if
             --infile2 '$input_options.infile2'
             --outfile_result '$outfile_result'
+            --outfile_history '$outfile_history'
             #if $save and 'save_estimator' in str($save)
             --outfile_object '$outfile_object'
             #end if
@@ -85,6 +86,7 @@
     </inputs>
     <outputs>
         <data format="tabular" name="outfile_result" />
+        <data format="tabular" name="outfile_history" />
         <data format="h5mlm" name="outfile_object" label="Fitted estimator or estimator skeleton on ${on_string}">
             <filter>str(save) and 'save_estimator' in str(save)</filter>
         </data>

--- a/tools/sklearn/keras_train_and_eval.xml
+++ b/tools/sklearn/keras_train_and_eval.xml
@@ -86,7 +86,7 @@
     </inputs>
     <outputs>
         <data format="tabular" name="outfile_result" />
-        <data format="tabular" name="outfile_history" />
+        <data format="tabular" name="outfile_history" label="Deep learning training history log on ${on_string}" />
         <data format="h5mlm" name="outfile_object" label="Fitted estimator or estimator skeleton on ${on_string}">
             <filter>str(save) and 'save_estimator' in str(save)</filter>
         </data>

--- a/tools/sklearn/keras_train_and_eval.xml
+++ b/tools/sklearn/keras_train_and_eval.xml
@@ -29,15 +29,15 @@
             #end if
             --infile2 '$input_options.infile2'
             --outfile_result '$outfile_result'
+            #if $save and 'save_csvlogger' in str($save)
+            --outfile_history '$outfile_history'
+            #end if
             #if $save and 'save_estimator' in str($save)
             --outfile_object '$outfile_object'
             #end if
             #if $save and 'save_prediction' in str($save)
             --outfile_y_true '$outfile_y_true'
             --outfile_y_preds '$outfile_y_preds'
-            #end if
-            #if $save and 'save_csvlogger' in str($save)
-            --outfile_history '$outfile_history'
             #end if
             #if $experiment_schemes.test_split.split_algos.shuffle == 'group'
             --groups '$experiment_schemes.test_split.split_algos.groups_selector.infile_g'
@@ -83,11 +83,14 @@
         <param name="save" type="select" multiple='true' display="checkboxes" label="Save the fitted model" optional="true" help="Evaluation scores will be output by default.">
             <option value="save_estimator" selected="true">Fitted estimator</option>
             <option value="save_prediction">True labels and prediction results from evaluation for downstream analysis</option>
-            <option value="save_csvlogger">Display CSVLogger if selected in the "Keras model builder" tool</option>
+            <option value="save_csvlogger">Display CSVLogger if selected as a callback in the Keras model builder tool</option>
         </param>
     </inputs>
     <outputs>
         <data format="tabular" name="outfile_result" />
+         <data format="tabular" name="outfile_history" label="Deep learning training history log on ${on_string}">
+            <filter>str(save) and 'save_csvlogger' in str(save)</filter>
+        </data>
         <data format="h5mlm" name="outfile_object" label="Fitted estimator or estimator skeleton on ${on_string}">
             <filter>str(save) and 'save_estimator' in str(save)</filter>
         </data>
@@ -96,9 +99,6 @@
         </data>
         <data format="tabular" name="outfile_y_preds" label="All predictions on ${on_string}">
             <filter>str(save) and 'save_prediction' in str(save)</filter>
-        </data>
-        <data format="tabular" name="outfile_history" label="Deep learning training history log on ${on_string}" />
-            <filter>str(save) and 'save_csvlogger' in str(save)</filter>
         </data>
     </outputs>
     <tests>

--- a/tools/sklearn/keras_train_and_eval.xml
+++ b/tools/sklearn/keras_train_and_eval.xml
@@ -8,7 +8,7 @@
     <expand macro="macro_stdio" />
     <version_command>echo "@VERSION@"</version_command>
     <command>
-        <![CDATA[
+        <![CDATA[        
         export HDF5_USE_FILE_LOCKING='FALSE';
         #if $input_options.selected_input == 'refseq_and_interval'
         bgzip -c '$input_options.target_file' > '${target_file.element_identifier}.gz' &&
@@ -29,7 +29,6 @@
             #end if
             --infile2 '$input_options.infile2'
             --outfile_result '$outfile_result'
-            --outfile_history '$outfile_history'
             #if $save and 'save_estimator' in str($save)
             --outfile_object '$outfile_object'
             #end if
@@ -37,10 +36,12 @@
             --outfile_y_true '$outfile_y_true'
             --outfile_y_preds '$outfile_y_preds'
             #end if
+            #if $save and 'save_csvlogger' in str($save)
+            --outfile_history '$outfile_history'
+            #end if
             #if $experiment_schemes.test_split.split_algos.shuffle == 'group'
             --groups '$experiment_schemes.test_split.split_algos.groups_selector.infile_g'
             #end if
-
         ]]>
     </command>
     <configfiles>
@@ -82,11 +83,11 @@
         <param name="save" type="select" multiple='true' display="checkboxes" label="Save the fitted model" optional="true" help="Evaluation scores will be output by default.">
             <option value="save_estimator" selected="true">Fitted estimator</option>
             <option value="save_prediction">True labels and prediction results from evaluation for downstream analysis</option>
+            <option value="save_csvlogger">Display CSVLogger if selected in the "Keras model builder" tool</option>
         </param>
     </inputs>
     <outputs>
         <data format="tabular" name="outfile_result" />
-        <data format="tabular" name="outfile_history" label="Deep learning training history log on ${on_string}" />
         <data format="h5mlm" name="outfile_object" label="Fitted estimator or estimator skeleton on ${on_string}">
             <filter>str(save) and 'save_estimator' in str(save)</filter>
         </data>
@@ -95,6 +96,9 @@
         </data>
         <data format="tabular" name="outfile_y_preds" label="All predictions on ${on_string}">
             <filter>str(save) and 'save_prediction' in str(save)</filter>
+        </data>
+        <data format="tabular" name="outfile_history" label="Deep learning training history log on ${on_string}" />
+            <filter>str(save) and 'save_csvlogger' in str(save)</filter>
         </data>
     </outputs>
     <tests>


### PR DESCRIPTION
The PR adds an output dataset for displaying training logs if selected as a callback in the Keras model builder tool.

To use it, one needs to select the CSVLogger callback in the "Keras Model Builder" tool and then in the "Deep learning training and evaluation conduct deep training and evaluation either implicitly or explicitly", check the "Display CSVLogger if selected as a callback in the Keras model builder tool" checkbox. 

"Keras Model Builder" tool 
![Screenshot from 2023-09-25 18-04-01](https://github.com/bgruening/galaxytools/assets/3022518/45606205-5e3c-475e-a8ab-3f4a939ce335)

"Deep learning training and evaluation conduct deep training and evaluation either implicitly or explicitly" tool

![Screenshot from 2023-09-25 18-03-08](https://github.com/bgruening/galaxytools/assets/3022518/e679815c-af21-4ad8-8b13-ecf366c2485b)


ping @qiagu @kxk302. Can you look at this feature and provide your feedback?

Thanks