### PR TITLE
hifiasm: version bump 0.19.7, add scaff options to wrapper

### DIFF
--- a/tools/hifiasm/hifiasm.xml
+++ b/tools/hifiasm/hifiasm.xml
@@ -117,8 +117,6 @@
         #end if
         #if str($scaffolding_options.scaffold_selector) == 'set':
             --dual-scaf 
-            -s $purge_options.similarity_threshold
-            -O $purge_options.minimum_overlap
             #if $scaffolding_options.scaf_gap:
                 --scaf-gap $scaffolding_options.scaf_gap
             #end if

--- a/tools/hifiasm/hifiasm.xml
+++ b/tools/hifiasm/hifiasm.xml
@@ -281,12 +281,11 @@
         </conditional>
         <conditional name="scaffolding_options">
             <param name="scaffold_selector" type="select" label="Options for hifiasm scaffolding">
-                <option value="blank">Leave default (no scaffolding)</option>
-                <option value="set">Specify</option>
+                <option value="blank">No scaffolding (default)</option>
+                <option value="set">Turn on hifiasm scaffolding</option>
             </param>
             <when value="blank" />
             <when value="set">
-                <param argument="--dual-scaf" type="boolean" label="Dual scaffold" help="Do you want to output scaffolds?" />
                 <param argument="--scaf-gap" type="integer" min="1" value="3000000" optional="true" label="Max scaffolding gap size" help="Set the max gap size of scaffolds (default is 3,000,000)" />
             </when>
         </conditional>

--- a/tools/hifiasm/hifiasm.xml
+++ b/tools/hifiasm/hifiasm.xml
@@ -1,7 +1,7 @@
 <tool id="hifiasm" name="Hifiasm" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>haplotype-resolved de novo assembler for PacBio Hifi reads</description>
     <macros>
-        <token name="@TOOL_VERSION@">0.19.5</token>
+        <token name="@TOOL_VERSION@">0.19.7</token>
         <token name="@VERSION_SUFFIX@">0</token>
         <token name="@FORMATS@">fasta,fasta.gz,fastq,fastq.gz</token>
         <xml name="reads">
@@ -113,6 +113,14 @@
             #end if
             #if $purge_options.n_hap:
                 --n-hap $purge_options.n_hap
+            #end if
+        #end if
+        #if str($scaffolding_options.scaffold_selector) == 'set':
+            --dual-scaf 
+            -s $purge_options.similarity_threshold
+            -O $purge_options.minimum_overlap
+            #if $scaffolding_options.scaf_gap:
+                --scaf-gap $scaffolding_options.scaf_gap
             #end if
         #end if
 
@@ -271,6 +279,17 @@
                     </sanitizer>
                     <validator type="regex">[0-9kKmMGg]+</validator>
                 </param>
+            </when>
+        </conditional>
+        <conditional name="scaffolding_options">
+            <param name="scaffold_selector" type="select" label="Options for hifiasm scaffolding">
+                <option value="blank">Leave default (no scaffolding)</option>
+                <option value="set">Specify</option>
+            </param>
+            <when value="blank" />
+            <when value="set">
+                <param argument="--dual-scaf" type="boolean" label="Dual scaffold" help="Do you want to output scaffolds?" />
+                <param argument="--scaf-gap" type="integer" min="1" value="3000000" optional="true" label="Max scaffolding gap size" help="Set the max gap size of scaffolds (default is 3,000,000)" />
             </when>
         </conditional>
         <param name="log_out" type="boolean" label="Output log file?" truevalue="yes" falsevalue="no" /> 


### PR DESCRIPTION
hello! 👋🏼 

version bumping hifiasm to 0.19.7 which adds the `--dual-scaf` and `--scaf-gap` parameters as options. i've added these to the wrapper, too. i'm not sure what to do about tests, i tried running hifiasm on the existing test input files both with and without the `--dual-scaf` option and the results don't change 🤔 