### PR TITLE
Updating tools/cellprofiler_v4 from version 4.2.1 to 4.2.6

### DIFF
--- a/tools/cellprofiler_v4/cellprofiler.xml
+++ b/tools/cellprofiler_v4/cellprofiler.xml
@@ -2,7 +2,7 @@
     <description>with CellProfiler 4</description>
     <macros>
         <import>macros.xml</import>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@VERSION_SUFFIX@">0</token>
         <xml name="test_assert_content" token_n="291">
             <assert_contents>
                 <has_n_lines n="@N@" />

--- a/tools/cellprofiler_v4/macros.xml
+++ b/tools/cellprofiler_v4/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">4.2.1</token>
+    <token name="@TOOL_VERSION@">4.2.6</token>
     <token name="@PY_VERSION@">3.8</token>
     <token name="@FORMATS@">jpg,png,tiff,bmp,gif,pcx,ppm,psd,pbm,pgm,eps</token>
     <token name="@SPACES@">"    "</token>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/cellprofiler_v4**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/cellprofiler_v4 from version 4.2.1 to 4.2.6.

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).