### PR TITLE
Updating tools/nextdenovo from version 2.5.0 to 2.5.2

### DIFF
--- a/tools/nextdenovo/macros.xml
+++ b/tools/nextdenovo/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.5.0</token>
+    <token name="@TOOL_VERSION@">2.5.2</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/nextdenovo**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/nextdenovo from version 2.5.0 to 2.5.2.

**Project home page:** https://github.com/Nextomics/NextDenovo/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).