### PR TITLE
Updating tools/tgsgapcloser from version 1.0.3 to 1.2.1

### DIFF
--- a/tools/tgsgapcloser/macros.xml
+++ b/tools/tgsgapcloser/macros.xml
@@ -1,14 +1,14 @@
 <macros>
-    <token name="@TOOL_VERSION@">1.0.3</token>
+    <token name="@TOOL_VERSION@">1.2.1</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">tgsgapcloser</requirement>
-            <requirement type="package" version="1.4.20">racon</requirement>
+            <requirement type="package" version="1.5.0">racon</requirement>
             <requirement type="package" version="2.21">which</requirement>
             <requirement type="package" version="1.24">pilon</requirement>
-            <requirement type="package" version="1.9">samtools</requirement> 
-            <requirement type="package" version="11.0.9.1">openjdk</requirement>
+            <requirement type="package" version="1.18">samtools</requirement> 
+            <requirement type="package" version="21.0.1">openjdk</requirement>
         </requirements>
     </xml>
     <xml name="xrefs">


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/tgsgapcloser**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/tgsgapcloser from version 1.0.3 to 1.2.1.

**Project home page:** https://github.com/BGI-Qingdao/TGS-GapCloser/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).