### PR TITLE
Updating tools/hifiasm from version 0.19.7 to 0.19.8

### DIFF
--- a/tools/hifiasm/hifiasm.xml
+++ b/tools/hifiasm/hifiasm.xml
@@ -1,8 +1,8 @@
 <tool id="hifiasm" name="Hifiasm" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>haplotype-resolved de novo assembler for PacBio Hifi reads</description>
     <macros>
-        <token name="@TOOL_VERSION@">0.19.7</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@TOOL_VERSION@">0.19.8</token>
+        <token name="@VERSION_SUFFIX@">0</token>
         <token name="@FORMATS@">fasta,fasta.gz,fastq,fastq.gz</token>
         <xml name="reads">
             <param name="reads" type="data" format="@FORMATS@" multiple="true" label="Input reads" />


### PR DESCRIPTION
Hello! This is an automated update of the following tool: **tools/hifiasm**. I created this PR because I think the tool's main dependency is out of date, i.e. there is a newer version available through conda.

I have updated tools/hifiasm from version 0.19.7 to 0.19.8.

**Project home page:** https://github.com/chhylp123/hifiasm/releases

For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new).