### PR TITLE
Fix two bugs with `split_file_to_collection`

### DIFF
--- a/tools/text_processing/split_file_to_collection/split_file_to_collection.py
+++ b/tools/text_processing/split_file_to_collection/split_file_to_collection.py
@@ -224,6 +224,7 @@ def split_by_record(args, in_file, out_dir, top, ftype):
             for i in range(top):
                 f.readline()
             n_records = 0
+            last_line_matched = False
             for line in f:
                 if (num == 0 and re.match(sep, line) is not None) or (
                     num > 0 and n_records % num == 0
@@ -241,7 +242,7 @@ def split_by_record(args, in_file, out_dir, top, ftype):
         if chunksize == 0:  # i.e. no chunking
             n_per_file = n_records // numnew
         else:
-            numnew = n_records // chunksize
+            numnew = max(n_records // chunksize, 1)  # should not be less than 1
             n_per_file = chunksize
 
     # make new files

--- a/tools/text_processing/split_file_to_collection/split_file_to_collection.xml
+++ b/tools/text_processing/split_file_to_collection/split_file_to_collection.xml
@@ -1,4 +1,4 @@
-<tool id="split_file_to_collection" name="Split file" version="0.5.0">
+<tool id="split_file_to_collection" name="Split file" version="0.5.1">
     <description>to dataset collection</description>
     <macros>
         <xml name="regex_sanitizer">


### PR DESCRIPTION
Allow chunksize to be greater than the number of records in the input file without raising the following error:

```
Traceback (most recent call last):
  File "/srv/galaxy/var/shed_tools/toolshed.g2.bx.psu.edu/repos/bgruening/split_file_to_collection/6cbe2f30c2d7/split_file_to_collection/split_file_to_collection.py", line 281, in <module>
    main()
  File "/srv/galaxy/var/shed_tools/toolshed.g2.bx.psu.edu/repos/bgruening/split_file_to_collection/6cbe2f30c2d7/split_file_to_collection/split_file_to_collection.py", line 52, in main
    split_by_record(args, in_file, out_dir, top, ftype)
  File "/srv/galaxy/var/shed_tools/toolshed.g2.bx.psu.edu/repos/bgruening/split_file_to_collection/6cbe2f30c2d7/split_file_to_collection/split_file_to_collection.py", line 169, in split_by_record
    new_file = open(newfile_names[new_file_counter], "a")
IndexError: list index out of range
```

Allow an empty file to be split without raising the following error:

```
Traceback (most recent call last):
  File "/srv/galaxy/var/shed_tools/toolshed.g2.bx.psu.edu/repos/bgruening/split_file_to_collection/6cbe2f30c2d7/split_file_to_collection/split_file_to_collection.py", line 281, in <module>
    main()
  File "/srv/galaxy/var/shed_tools/toolshed.g2.bx.psu.edu/repos/bgruening/split_file_to_collection/6cbe2f30c2d7/split_file_to_collection/split_file_to_collection.py", line 52, in main
    split_by_record(args, in_file, out_dir, top, ftype)
  File "/srv/galaxy/var/shed_tools/toolshed.g2.bx.psu.edu/repos/bgruening/split_file_to_collection/6cbe2f30c2d7/split_file_to_collection/split_file_to_collection.py", line 141, in split_by_record
    if sep_at_end and not last_line_matched:
UnboundLocalError: local variable 'last_line_matched' referenced before assignment
```