### PR TITLE
bumped to 2.9.3

### DIFF
--- a/tools/flye/flye.xml
+++ b/tools/flye/flye.xml
@@ -301,7 +301,7 @@
             <param name="inputs" ftype="fastq.gz" value="ecoli_hifi_01.fastq.gz,ecoli_hifi_02.fastq.gz,ecoli_hifi_03.fastq.gz,ecoli_hifi_04.fastq.gz,ecoli_hifi_05.fastq.gz,ecoli_hifi_06.fastq.gz,ecoli_hifi_07.fastq.gz,ecoli_hifi_08.fastq.gz,ecoli_hifi_09.fastq.gz"/>
             <param name="mode" value="--nano-hq"/>
             <param name="min_overlap" value="1000"/>
-            <param name="scaffolding" value="true"/>
+            <param name="scaffold" value="true"/>
             <output name="assembly_info" ftype="tabular">
                 <assert_contents>
                     <has_size value="286" delta="100"/>

--- a/tools/flye/macros.xml
+++ b/tools/flye/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.9.1</token>
+    <token name="@TOOL_VERSION@">2.9.3</token>
     <token name="@SUFFIX_VERSION@">0</token>
     <xml name="requirements">
         <requirements>


### PR DESCRIPTION
No significant breaks, just a few improvements 
> Flye 2.9.3 release (28 November 2023)
Disjointig step speedup for --nano-hq mode
Improved --keep-haplotypes mode preserves more heterozygous SVs
A few bug fixes