### PR TITLE
update v08 to fix meme version check error

### DIFF
--- a/tools/rna_tools/rbpbench/macros.xml
+++ b/tools/rna_tools/rbpbench/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.7</token>
+    <token name="@TOOL_VERSION@">0.8</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@profile@">22.05</token>
     <xml name="requirements">

--- a/tools/rna_tools/rbpbench/rbpbench.xml
+++ b/tools/rna_tools/rbpbench/rbpbench.xml
@@ -100,6 +100,8 @@
                         --plotly-js-mode 4
                     #end if
                 #end if
+                --meme-no-check
+                --meme-no-pgc
 
             #if $action_type.search_output_options.search_report:
                 &&
@@ -146,6 +148,8 @@
                     $i.dataset_method_id 
                 #end for
                 @COMMON_PARAMS@
+                --meme-no-check
+                --meme-no-pgc
 
         #elif $action_type.action_type_selector == 'batch_table_search_motifs':
             @PREPARE_REF@
@@ -162,6 +166,8 @@
                     $i.element_identifier
                 #end for
                 @COMMON_PARAMS@
+                --meme-no-check
+                --meme-no-pgc
 
         #elif $action_type.action_type_selector == 'plot_nt_dist':
             @PREPARE_REF@


### PR DESCRIPTION
This update should fix the cryptic meme version check error which currently occurs in the live version. Version check is now disabled, and rbpbench is setup to work specifically with meme version 5.5.4 which is set as requirement in macros.xml.