### PR TITLE
Added bio.tools ref to mcl

### DIFF
--- a/tools/mcl/mcl.xml
+++ b/tools/mcl/mcl.xml
@@ -1,5 +1,8 @@
 <tool id="mcl_clustering" name="MCL"  version="14.137">
     <description>A Markov Cluster Algorithm.</description>
+    <xrefs>
+        <xref type="bio.tools">mcl</xref>
+    </xrefs>
     <requirements>
         <requirement type="package" version="14.137">mcl</requirement>
     </requirements>

--- a/tools/mcl/mcl.xml
+++ b/tools/mcl/mcl.xml
@@ -80,30 +80,6 @@ vary this parameter to obtain clusterings at different levels of granularity. A 
     fit hit 0.5
     hit bit 0.16
 
-
-----------
-References
-----------
-
-If you use MCL-edge software in your research, please cite it as you would cite a journal or a book. 
-This includes papers published in regular or electronic journals, usage of MCL-edge as a back-end to a database that is accessible via a web interface,
-or inclusion of MCL-edge in a larger framework of software that is distributed for other people to use. Include at least one of the following citations:
-
-Stijn van Dongen, Graph Clustering by Flow Simulation, PhD thesis, University of Utrecht, May 2000.
-( http://www.library.uu.nl/digiarchief/dip/diss/1895620/inhoud.htm )
-
-Stijn van Dongen, A cluster algorithm for graphs, Technical Report INS-R0010, National Research Institute for Mathematics and Computer Science in the Netherlands, Amsterdam, May 2000.
-( http://www.cwi.nl/ftp/CWIreports/INS/INS-R0010.ps.Z )
-
-Stijn van Dongen, Graph clustering via a discrete uncoupling process, Siam Journal on Matrix Analysis and Applications 30-1, p121-141, 2008.
-
-Stijn van Dongen and Cei Abreu-Goodger, Using MCL to extract clusters from networks, in Bacterial Molecular Networks: Methods and Protocols, Methods in Molecular Biology, Vol 804, pages 281—295 (2012). PMID 22144159.
-
-and add proper attributions to the MCL-edge home page http://micans.org/mcl/. For biological applications, it is appropriate to cite, additionally, the reference article for the first application of MCL to biological data:
-
-Enright A.J., Van Dongen S., Ouzounis C.A., An efficient algorithm for large-scale detection of protein families, Nucleic Acids Research 30(7):1575-1584 (2002).
-
-
 **Galaxy Wrapper Author**::
 
     *  Bjoern Gruening, University of Freiburg

--- a/tools/mcl/mcl.xml
+++ b/tools/mcl/mcl.xml
@@ -80,13 +80,12 @@ vary this parameter to obtain clusterings at different levels of granularity. A 
     fit hit 0.5
     hit bit 0.16
 
-**Galaxy Wrapper Author**::
-
-    *  Bjoern Gruening, University of Freiburg
-    *  Pavan Videm , University of Freiburg
-
 ]]>
     </help>
+    <creator>
+        <person givenName="Björn" familyName="Grüning" url="https://github.com/bgruening" />
+        <person givenName="Pavankumar" familyName="Videm" url="https://github.com/pavanvidem" />
+    </creator>
     <citations>
         <citation type="doi">10.1137/040608635</citation>
     </citations>

--- a/tools/mcl/mcl.xml
+++ b/tools/mcl/mcl.xml
@@ -111,4 +111,7 @@ Enright A.J., Van Dongen S., Ouzounis C.A., An efficient algorithm for large-sca
 
 ]]>
     </help>
+    <citations>
+        <citation type="doi">10.1137/040608635</citation>
+    </citations>
 </tool>


### PR DESCRIPTION
This PR links mcl to its bio.tools [entry](https://bio.tools/mcl).