### PR TITLE
add graphprot log output to find error in Galaxy version

### DIFF
--- a/tools/rna_tools/graphprot/graphprot_train_predict.xml
+++ b/tools/rna_tools/graphprot/graphprot_train_predict.xml
@@ -20,6 +20,7 @@
                 $action_type.training_options.disable_cv
                 $action_type.training_options.disable_motifs
                 --min-train $action_type.training_options.min_train
+                --gp-output
 
         #elif $action_type.action_type_selector == 'predict':
             python '$__tool_directory__/graphprot_predict_wrapper.py'
@@ -35,6 +36,7 @@
                 --ap-extlr $action_type.prediction_options.ap_extlr
                 $action_type.prediction_options.conf_out
                 $action_type.prediction_options.ws_pred_out
+                --gp-output
         #end if
 
 


### PR DESCRIPTION
Hi, 
GraphProt on Galaxy currently does not work. I added the --gp-output to also get GraphProt log outputs, otherwise there is no way telling what the issue is. Offline GraphProt conda version fresh install works fine with the Galaxy python wrapper scripts, just tried.
Best,
Michael   