### PR TITLE
Add missing format attribute

### DIFF
--- a/tools/GraphClust/CollectResults/glob_report.xml
+++ b/tools/GraphClust/CollectResults/glob_report.xml
@@ -147,8 +147,8 @@
     <collection name="allFasta" type="list" label="sequences.fa">
       <discover_datasets format="fasta" pattern="(?P&lt;name&gt;^.*\.all.fa$)" directory="RESULTS"  />
     </collection>
-    <collection name="partitions" type="list" label="Partitions">
-      <discover_datasets pattern="(?P&lt;name&gt;^.*$)" directory="RESULTS/partitions" />
+    <collection name="partitions" type="list" label="Partitions" format="txt">
+      <discover_datasets pattern="(?P&lt;name&gt;^.*$)" directory="RESULTS/partitions" format="txt" />
     </collection>
     <collection name="topSecondaryStruct" type="list" label="Top $results_top_num alirna.ps">
       <discover_datasets format="png" pattern="(?P&lt;name&gt;^.*\.alirna.png$)"  />

--- a/tools/GraphClust/CollectResultsNoAlign/glob_report_no_align.xml
+++ b/tools/GraphClust/CollectResultsNoAlign/glob_report_no_align.xml
@@ -100,8 +100,8 @@
       <discover_datasets format="fasta" pattern="(?P&lt;name&gt;^.*\.sorted.fa$)" directory="RESULTS"  />
     </collection>
 
-    <collection name="partitions" type="list" label="Partitions">
-      <discover_datasets pattern="(?P&lt;name&gt;^.*$)" directory="RESULTS/partitions" />
+    <collection name="partitions" type="list" label="Partitions" format="txt">
+      <discover_datasets pattern="(?P&lt;name&gt;^.*$)" directory="RESULTS/partitions" format="txt"/>
     </collection>
     <data name="RESULTS_zip" format="zip" from_work_dir="RESULTS.zip" label="RESULTS.zip"  />
   </outputs>


### PR DESCRIPTION
Add mising format attributes

We can find them with
```
planemo lint -s command,tool_xsd,tests,general,help,inputs,citations,xml_order  --recursive
```
If we don't set an output format the hda extension becomes null in the database, and we fail at various places in the galaxy codebase. We can make Galaxy more resilient to it, but this is an easy fix here. Galaxy issue is here: https://github.com/galaxyproject/galaxy/issues/18383

There are more tools, but they produce some compressed bz2 file:
```
Linting tool /Users/mvandenb/src/galaxytools/tools/GraphClust/Structure_GSPAN/structure_to_gspan.xml
Applying linter output... WARNING
.. WARNING: Tool collection output gspan_compressed doesn't define an output format.
.. INFO: 1 outputs found.
Failed linting
Linting tool /Users/mvandenb/src/galaxytools/tools/GraphClust/GSPAN/fasta2shrep_gspan.xml
Applying linter output... WARNING
.. WARNING: Tool collection output gspan_compressed doesn't define an output format.
.. INFO: 1 outputs found.
Failed linting
```