### PR TITLE
Fix cut tool

### DIFF
--- a/tools/text_processing/text_processing/cut.xml
+++ b/tools/text_processing/text_processing/cut.xml
@@ -1,4 +1,4 @@
-<tool id="tp_cut_tool" name="Advanced Cut" version="@TOOL_VERSION@+galaxy2" profile="@PROFILE@">
+<tool id="tp_cut_tool" name="Advanced Cut" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>columns from a table (cut)</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/text_processing/text_processing/cut.xml
+++ b/tools/text_processing/text_processing/cut.xml
@@ -1,4 +1,4 @@
-<tool id="tp_cut_tool" name="Advanced Cut" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
+<tool id="tp_cut_tool" name="Advanced Cut" version="@TOOL_VERSION@+galaxy2" profile="@PROFILE@">
     <description>columns from a table (cut)</description>
     <macros>
         <import>macros.xml</import>

--- a/tools/text_processing/text_processing/cut.xml
+++ b/tools/text_processing/text_processing/cut.xml
@@ -1,4 +1,4 @@
-<tool id="tp_cut_tool" name="Advanced Cut" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
+<tool id="tp_cut_tool" name="Advanced Cut" version="@TOOL_VERSION@+galaxy2" profile="@PROFILE@">
     <description>columns from a table (cut)</description>
     <macros>
         <import>macros.xml</import>
@@ -13,10 +13,10 @@
             #if $cut_type_options.cut_element != '-f'
                 '$cut_type_options.list'
             #else
+                '$cut_type_options.colnames_option.list'
                 #if str($cut_type_options.delimiter) != '':
                     -d"$cut_type_options.delimiter"
                 #end if
-                '$cut_type_options.colnames_option.list'
             #end if
             '$input'
         > '$output'
@@ -194,7 +194,11 @@
             <param name="list" value="1,3,4"/>
             <param name="delimiter" value=""/>
             <output name="output" file="cut_results1.txt"/>
+            <assert_command>
+                <has_text text="-f '1,3,4'"/>
+            </assert_command>
         </test>
+
         <test expect_num_outputs="1">
             <param name="input" value="cut1.txt"/>
             <conditional name="cut_type_options">
@@ -207,6 +211,9 @@
             </conditional>
             <param name="complement" value="--complement" />
             <output name="output" file="cut_results2.txt"/>
+            <assert_command>
+                <has_text text="-f '2'"/>
+            </assert_command>
         </test>
         <test expect_num_outputs="1">
             <param name="input" value="cut1.txt"/>

--- a/tools/text_processing/text_processing/macros.xml
+++ b/tools/text_processing/text_processing/macros.xml
@@ -6,7 +6,7 @@
         </requirements>
     </xml>
     <token name="@TOOL_VERSION@">9.3</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">2</token>
     <token name="@PROFILE@">23.1</token>
     <xml name="stdio">
         <stdio>

--- a/tools/text_processing/text_processing/macros.xml
+++ b/tools/text_processing/text_processing/macros.xml
@@ -6,7 +6,7 @@
         </requirements>
     </xml>
     <token name="@TOOL_VERSION@">9.3</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">23.1</token>
     <xml name="stdio">
         <stdio>

--- a/tools/text_processing/text_processing/sort_rows.xml
+++ b/tools/text_processing/text_processing/sort_rows.xml
@@ -18,7 +18,6 @@
     <outputs>
         <data name="outfile" format_source="infile" metadata_source="infile"/>
     </outputs>
-    <options sanitize="False"/>
     <tests>
         <test>
             <param name="infile" value="sort_rows1.tabular" ftype="tabular" />


### PR DESCRIPTION
the list of columns must be after `-f` (or `-c` i.e. `cut_element`). I would have liked to add a test, but we can not use an option with the value `","` in a test (it will split it to a list of options `["", ""]`).

Still broken is that `data_column` parameters do not work for anything besides tab and comma separated values. Fixing this properly would require a restructuring of the tool form....
