### PR TITLE
Updating .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,13 +39,13 @@ nosetests.xml
 
 *.7z
 *.dmg
-*.gz
+#*.gz
 *.iso
 *.jar
 *.rar
 *.tar
 *.zip
-*.bz
+#*.bz
 *.bz2
 .hg
 *.swp


### PR DESCRIPTION
This PR updates the .gitignore file in the repository, aligning it with the .gitignore from the IUC [repository](https://github.com/galaxyproject/tools-iuc/blob/main/.gitignore). 

The changes address issue that occurred when trying to push files with certain extensions (e.g., .gz, .bz). 