### PR TITLE
Fix homepage URL for flux tool

### DIFF
--- a/tools/flux/.shed.yml
+++ b/tools/flux/.shed.yml
@@ -6,7 +6,7 @@ long_description: |
   Users can specify the model (dev,schnell),and provide prompt.
   The tool will then generate and return the corresponding image based on the input provided.
 remote_repository_url: https://github.com/bgruening/galaxytools/tree/master/tools/flux
-homepage_url: https://github.com/bgruening/galaxytools/tree/master/tools/cflux
+homepage_url: https://github.com/bgruening/galaxytools/tree/master/tools/flux
 type:
 categories:
   - Machine Learning


### PR DESCRIPTION
The homepage URL for the flux tool was incorrect and pointed to the wrong location.