### PR TITLE
update ftp link in blobtoolkit.xml

### DIFF
--- a/tools/blobtoolkit/blobtoolkit.xml
+++ b/tools/blobtoolkit/blobtoolkit.xml
@@ -477,7 +477,7 @@
     
 **NCBI taxdump directory**
 
-The taxdump database, provided by NCBI, includes the taxonomic lineage of taxa, information on type strains and material, and host information. The file **new_taxdump.tar.gz** can be downloaded from the taxonomy directory on the `FTP site <ftp.ncbi.nlm.nih.gov/pub/taxonomy/new_taxdump/>`_. 
+The taxdump database, provided by NCBI, includes the taxonomic lineage of taxa, information on type strains and material, and host information. The file **new_taxdump.tar.gz** can be downloaded from the taxonomy directory on the `FTP site <https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/new_taxdump/>`_. 
     
     ]]></help>
     <expand macro="citations"/>


### PR DESCRIPTION
The ftp url (ftp.ncbi.nlm.nih.gov/pub/taxonomy/new_taxdump/) of the taxdump is a broken link in the help section of the wrapper. The ftp link will be redirected to a ftp url with Galaxy prefix (i.e  https://usegalaxy.org.au/ftp.ncbi.nlm.nih.gov/pub/taxonomy/new_taxdump/) . I updated the broken ftp url with to https://ftp.ncbi.nlm.nih.gov/pub/taxonomy/new_taxdump/ instead of ftp.ncbi.nlm.nih.gov/pub/taxonomy/new_taxdump/ and it should work now.

Thanks 