### PR TITLE
Drop datatype repository dependencies for infernal tools

### DIFF
--- a/tools/rna_tools/infernal/repository_dependencies.xml
+++ b/tools/rna_tools/infernal/repository_dependencies.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0"?>
-<repositories description="This requires the datatype definitions for Multiple Sequence Alignment (MSA) formats (e.g. STOCKHOLM, SELEX, ClustalW).">
-    <repository name="msa_datatypes" owner="iuc" />
-</repositories>


### PR DESCRIPTION
AFAICT they are all in Galaxy now and we've deprecated loading TS datatypes a few years ago.