### PR TITLE
Add an admin-definable limit to the number of outputs rbc_splitfasta will create

### DIFF
--- a/tools/splitfasta/.shed.yml
+++ b/tools/splitfasta/.shed.yml
@@ -1,9 +1,10 @@
 categories:
 - Text Manipulation
 description: Split a multi-sequence fasta file into files containing single sequences
-long-description: |
+long_description: |
     Very basic utility, that grabs lines two by two, and writes them to a file.
 name: splitfasta
 owner: rnateam
 remote_repository_url: https://github.com/bgruening/galaxytools/tree/master/tools/splitfasta
+homepage_url: https://github.com/bgruening/galaxytools/tree/master/tools/splitfasta
 type: unrestricted

--- a/tools/splitfasta/splitFasta.xml
+++ b/tools/splitfasta/splitFasta.xml
@@ -1,4 +1,4 @@
-<tool id="rbc_splitfasta" name="Split Fasta" version="0.4.0">
+<tool id="rbc_splitfasta" name="Split Fasta" version="0.5.0">
     <description>files into a collection</description>
     <requirements>
         <requirement type="package" version="1.76">biopython</requirement>
@@ -6,9 +6,9 @@
     <command detect_errors="aggressive">
     <![CDATA[
         #if $splitmode.splitmode_select == "each":
-            python $__tool_directory__/split_fasta.py '$inputFile'
+            python $__tool_directory__/split_fasta.py --records '$inputFile.metadata.sequences' --limit "\${GALAXY_FILE_LIMIT:-0}" '$inputFile'
         #else if $splitmode.splitmode_select == "chunks":
-            python $__tool_directory__/split_fasta.py '$inputFile' $splitmode.num_chunks
+            python $__tool_directory__/split_fasta.py --records '$inputFile.metadata.sequences' --limit "\${GALAXY_FILE_LIMIT:-0}" --num-chunks '$splitmode.num_chunks' '$inputFile'
         #end if
     ]]></command>
     <inputs>

--- a/tools/splitfasta/splitFasta.xml
+++ b/tools/splitfasta/splitFasta.xml
@@ -1,4 +1,4 @@
-<tool id="rbc_splitfasta" name="Split Fasta" version="0.5.0">
+<tool id="rbc_splitfasta" name="Split Fasta" version="0.5.0" profile="23.0">
     <description>files into a collection</description>
     <requirements>
         <requirement type="package" version="1.76">biopython</requirement>

--- a/tools/splitfasta/split_fasta.py
+++ b/tools/splitfasta/split_fasta.py
@@ -42,7 +42,6 @@ with open(input_filename) as input_file:
     chunk_record_count = 0  # how many lines have we written to the output file
     records = []
     for record in SeqIO.parse(input_file, "fasta"):
-        print(f"processing record {record}")
         records.append(record)
         if num_chunks == 0 or (
             count < num_chunks and len(records) >= records_per_chunk

--- a/tools/splitfasta/split_fasta.py
+++ b/tools/splitfasta/split_fasta.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 
-import os
-import sys
 import argparse
+import os
 
 from Bio import SeqIO
 

--- a/tools/splitfasta/split_fasta.py
+++ b/tools/splitfasta/split_fasta.py
@@ -2,30 +2,40 @@
 
 import os
 import sys
+import argparse
 
 from Bio import SeqIO
 
-num_chunks = 0
-if len(sys.argv) == 3:
-    num_chunks = int(sys.argv[2])
-    input_filename = sys.argv[1]
-elif len(sys.argv) == 2:
-    input_filename = sys.argv[1]
-else:
-    exit("Usage: split_fasta.py <input_filename> [<num_chunks>]")
+parser = argparse.ArgumentParser()
+parser.add_argument("--records", type=int, default=None)
+parser.add_argument("--limit", type=int, default=None)
+parser.add_argument("--num-chunks", type=int, default=0)
+parser.add_argument("input_file")
+args = parser.parse_args()
+
+input_filename = args.input_file
+num_chunks = args.num_chunks
+record_count = args.records
+record_limit = args.limit
 
 os.mkdir("splits")
 
-if num_chunks != 0:
-    # if splitting into chunks we need to count how many records are in the
-    # input file
+if record_limit and num_chunks > record_limit:
+    exit(f"ERROR: Requested number of chunks {num_chunks} exceeds limit {record_limit}")
+
+if not record_count and (num_chunks != 0 or record_limit):
+    # if no count is provided and if splitting into chunks or a limit is set, we need to count how many records are in the input file
     record_count = 0
     with open(input_filename) as input_file:
         for line in input_file:
             if line.lstrip().startswith(">"):
                 record_count += 1
 
+if num_chunks != 0:
     records_per_chunk = round(float(record_count) / num_chunks)
+
+if record_limit and record_count > record_limit:
+    exit(f"ERROR: Number of sequences {record_count} exceeds limit {record_limit}")
 
 count = 1
 with open(input_filename) as input_file:
@@ -33,6 +43,7 @@ with open(input_filename) as input_file:
     chunk_record_count = 0  # how many lines have we written to the output file
     records = []
     for record in SeqIO.parse(input_file, "fasta"):
+        print(f"processing record {record}")
         records.append(record)
         if num_chunks == 0 or (
             count < num_chunks and len(records) >= records_per_chunk


### PR DESCRIPTION
I went with a default of unlimited but could also set some reasonable default if anyone has suggestions.

Additionally the tool will now use the sequence count (if available, although I believe it is [always available](https://github.com/galaxyproject/galaxy/blob/9fc0f0593517612f14c612c1648c2dc1a040f545/lib/galaxy/datatypes/sequence.py#L374)) from metadata rather than calculating it.