### PR TITLE
Fixed Tiara tool error in certain cases

### DIFF
--- a/tools/tiara/tiara.xml
+++ b/tools/tiara/tiara.xml
@@ -1,4 +1,4 @@
-<tool id="tiara" name="tiara" version="@TOOL_VERSION@+galaxy1" profile="21.05">
+<tool id="tiara" name="tiara" version="@TOOL_VERSION@+galaxy2" profile="21.05">
     <description>Deep-learning-based approach for identification of eukaryotic sequences in the metagenomic data </description>
     <macros>
         <import>macros.xml</import>
@@ -34,7 +34,7 @@
             #end for
             #for $tf in $taxonomy_filter
               && ls -l ./results/
-              &&  mv ./results/${tf}*.dat ./results/${tf}.fasta
+              && find ./results/ -name ${tf}*.dat -exec mv {} ./results/${tf}.fasta ';'
             #end for
         #end if
 

--- a/tools/tiara/tiara.xml
+++ b/tools/tiara/tiara.xml
@@ -33,7 +33,6 @@
                 $tf
             #end for
             #for $tf in $taxonomy_filter
-              && ls -l ./results/
               && find ./results/ -name ${tf}*.dat -exec mv {} ./results/${tf}.fasta ';'
             #end for
         #end if


### PR DESCRIPTION
Minor change to the Tiara tool to fix the situation explained below.

Tiara does not create an output file for a class it could not classify sequences for. However, in the command section we rename files using the 'mv' command based on the user-selected classes rather than the tool output. Hence when no sequences are classified as, for example, bacteria, the 'mv' command will still attempt to rename bac*.dat to bac.fasta and exit with error code 1. 

I also took out the 'ls -l ./results/' line which seems to be a leftover from debugging. 