### PR TITLE
Updates font stack for diff table

### DIFF
--- a/tools/diff/diff.xml
+++ b/tools/diff/diff.xml
@@ -2,7 +2,7 @@
     <description>analyzes two files and generates an unidiff text file with information about the differences and an optional Html report</description>
     <macros>
         <token name="@TOOL_VERSION@">3.10</token>
-        <token name="@GALAXY_VERSION@">0</token>
+        <token name="@GALAXY_VERSION@">1</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">diffutils</requirement>

--- a/tools/diff/template.html
+++ b/tools/diff/template.html
@@ -167,7 +167,7 @@
         .d2h-diff-table {
             width: 100%;
             border-collapse: collapse;
-            font-family: Menlo, Consolas, monospace;
+            font-family: "Noto Sans Mono CJK TC", Menlo, Consolas, monospace;
             font-size: 13px
         }
 


### PR DESCRIPTION
This PR replaces the default monospace font with `Noto Sans Mono CJK TC` for improved readability and better support for CJK characters (Chinese monospace font).

|Before|After|
|---|---|
|![before](https://github.com/user-attachments/assets/ed54c322-5fb8-44ed-9a55-b7bb7e7f9ee5)|![after](https://github.com/user-attachments/assets/3df93c97-3e71-4066-99f2-e2ce6df36721)|