### PR TITLE
trim_galore -> 0.6.10 with updated tests

### DIFF
--- a/tools/trim_galore/macros.xml
+++ b/tools/trim_galore/macros.xml
@@ -1,6 +1,6 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.6.7</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@TOOL_VERSION@">0.6.10</token>
+    <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">trim-galore</requirement>

--- a/tools/trim_galore/test-data/paired_collection_example_results3.txt
+++ b/tools/trim_galore/test-data/paired_collection_example_results3.txt
@@ -3,9 +3,9 @@ SUMMARISING RUN PARAMETERS
 ==========================
 Input filename: input_1.fastq
 Trimming mode: paired-end
-Trim Galore version: 0.6.7
-Cutadapt version: 3.4
-Python version: could not detect
+Trim Galore version: 0.6.10
+Cutadapt version: 5.0
+Python version: 3.12.10
 Number of cores used for trimming: 4
 Quality Phred score cutoff: 20
 Quality encoding type selected: ASCII+33
@@ -18,10 +18,9 @@ Length cut-off for read 1: 35 bp (default)
 Length cut-off for read 2: 35 bp (default)
 
 
-This is cutadapt 3.4 with Python 3.9.6
+This is cutadapt 5.0 with Python 3.12.10
 Command line parameters: -j 4 -e 0.1 -q 20 -O 1 -a CTGTCTCTTATA input_1.fastq
-Processing reads on 4 cores in single-end mode ...
-Finished in 0.01 s (115 µs/read; 0.52 M reads/minute).
+Processing single-end reads on 4 cores ...
 
 === Summary ===
 
@@ -37,6 +36,7 @@ Total written (filtered):         23,339 bp (93.9%)
 
 Sequence: CTGTCTCTTATA; Type: regular 3'; Length: 12; Trimmed: 52 times
 
+Minimum overlap: 1
 No. of allowed errors:
 1-9 bp: 0; 10-12 bp: 1
 
@@ -87,9 +87,9 @@ SUMMARISING RUN PARAMETERS
 ==========================
 Input filename: input_2.fastq
 Trimming mode: paired-end
-Trim Galore version: 0.6.7
-Cutadapt version: 3.4
-Python version: could not detect
+Trim Galore version: 0.6.10
+Cutadapt version: 5.0
+Python version: 3.12.10
 Number of cores used for trimming: 4
 Quality Phred score cutoff: 20
 Quality encoding type selected: ASCII+33
@@ -102,10 +102,9 @@ Length cut-off for read 1: 35 bp (default)
 Length cut-off for read 2: 35 bp (default)
 
 
-This is cutadapt 3.4 with Python 3.9.6
+This is cutadapt 5.0 with Python 3.12.10
 Command line parameters: -j 4 -e 0.1 -q 20 -O 1 -a CTGTCTCTTATA input_2.fastq
-Processing reads on 4 cores in single-end mode ...
-Finished in 0.02 s (159 µs/read; 0.38 M reads/minute).
+Processing single-end reads on 4 cores ...
 
 === Summary ===
 
@@ -121,6 +120,7 @@ Total written (filtered):         23,035 bp (92.7%)
 
 Sequence: CTGTCTCTTATA; Type: regular 3'; Length: 12; Trimmed: 58 times
 
+Minimum overlap: 1
 No. of allowed errors:
 1-9 bp: 0; 10-12 bp: 1
 

--- a/tools/trim_galore/test-data/paired_collection_example_results3gz.txt
+++ b/tools/trim_galore/test-data/paired_collection_example_results3gz.txt
@@ -3,9 +3,9 @@ SUMMARISING RUN PARAMETERS
 ==========================
 Input filename: input_1.fastq.gz
 Trimming mode: paired-end
-Trim Galore version: 0.6.7
-Cutadapt version: 3.4
-Python version: could not detect
+Trim Galore version: 0.6.10
+Cutadapt version: 5.0
+Python version: 3.12.10
 Number of cores used for trimming: 4
 Quality Phred score cutoff: 20
 Quality encoding type selected: ASCII+33
@@ -19,10 +19,9 @@ Length cut-off for read 2: 35 bp (default)
 Output file will be GZIP compressed
 
 
-This is cutadapt 3.4 with Python 3.9.6
+This is cutadapt 5.0 with Python 3.12.10
 Command line parameters: -j 4 -e 0.1 -q 20 -O 1 -a CTGTCTCTTATA input_1.fastq.gz
-Processing reads on 4 cores in single-end mode ...
-Finished in 0.01 s (129 µs/read; 0.47 M reads/minute).
+Processing single-end reads on 4 cores ...
 
 === Summary ===
 
@@ -38,6 +37,7 @@ Total written (filtered):         23,339 bp (93.9%)
 
 Sequence: CTGTCTCTTATA; Type: regular 3'; Length: 12; Trimmed: 52 times
 
+Minimum overlap: 1
 No. of allowed errors:
 1-9 bp: 0; 10-12 bp: 1
 
@@ -88,9 +88,9 @@ SUMMARISING RUN PARAMETERS
 ==========================
 Input filename: input_2.fastq.gz
 Trimming mode: paired-end
-Trim Galore version: 0.6.7
-Cutadapt version: 3.4
-Python version: could not detect
+Trim Galore version: 0.6.10
+Cutadapt version: 5.0
+Python version: 3.12.10
 Number of cores used for trimming: 4
 Quality Phred score cutoff: 20
 Quality encoding type selected: ASCII+33
@@ -104,10 +104,9 @@ Length cut-off for read 2: 35 bp (default)
 Output file will be GZIP compressed
 
 
-This is cutadapt 3.4 with Python 3.9.6
+This is cutadapt 5.0 with Python 3.12.10
 Command line parameters: -j 4 -e 0.1 -q 20 -O 1 -a CTGTCTCTTATA input_2.fastq.gz
-Processing reads on 4 cores in single-end mode ...
-Finished in 0.04 s (395 µs/read; 0.15 M reads/minute).
+Processing single-end reads on 4 cores ...
 
 === Summary ===
 
@@ -123,6 +122,7 @@ Total written (filtered):         23,035 bp (92.7%)
 
 Sequence: CTGTCTCTTATA; Type: regular 3'; Length: 12; Trimmed: 58 times
 
+Minimum overlap: 1
 No. of allowed errors:
 1-9 bp: 0; 10-12 bp: 1
 

--- a/tools/trim_galore/test-data/paired_example_results2.txt
+++ b/tools/trim_galore/test-data/paired_example_results2.txt
@@ -3,9 +3,9 @@ SUMMARISING RUN PARAMETERS
 ==========================
 Input filename: input_1.fastq
 Trimming mode: paired-end
-Trim Galore version: 0.6.7
-Cutadapt version: 3.4
-Python version: could not detect
+Trim Galore version: 0.6.10
+Cutadapt version: 5.0
+Python version: 3.12.10
 Number of cores used for trimming: 4
 Quality Phred score cutoff: 20
 Quality encoding type selected: ASCII+33
@@ -16,10 +16,9 @@ Minimum required adapter overlap (stringency): 1 bp
 Minimum required sequence length for both reads before a sequence pair gets removed: 20 bp
 
 
-This is cutadapt 3.4 with Python 3.9.6
+This is cutadapt 5.0 with Python 3.12.10
 Command line parameters: -j 4 -e 0.1 -q 20 -O 1 -a CTGTCTCTTATA input_1.fastq
-Processing reads on 4 cores in single-end mode ...
-Finished in 0.01 s (117 µs/read; 0.51 M reads/minute).
+Processing single-end reads on 4 cores ...
 
 === Summary ===
 
@@ -35,6 +34,7 @@ Total written (filtered):         23,339 bp (93.9%)
 
 Sequence: CTGTCTCTTATA; Type: regular 3'; Length: 12; Trimmed: 52 times
 
+Minimum overlap: 1
 No. of allowed errors:
 1-9 bp: 0; 10-12 bp: 1
 
@@ -85,9 +85,9 @@ SUMMARISING RUN PARAMETERS
 ==========================
 Input filename: input_2.fastq
 Trimming mode: paired-end
-Trim Galore version: 0.6.7
-Cutadapt version: 3.4
-Python version: could not detect
+Trim Galore version: 0.6.10
+Cutadapt version: 5.0
+Python version: 3.12.10
 Number of cores used for trimming: 4
 Quality Phred score cutoff: 20
 Quality encoding type selected: ASCII+33
@@ -98,10 +98,9 @@ Minimum required adapter overlap (stringency): 1 bp
 Minimum required sequence length for both reads before a sequence pair gets removed: 20 bp
 
 
-This is cutadapt 3.4 with Python 3.9.6
+This is cutadapt 5.0 with Python 3.12.10
 Command line parameters: -j 4 -e 0.1 -q 20 -O 1 -a CTGTCTCTTATA input_2.fastq
-Processing reads on 4 cores in single-end mode ...
-Finished in 0.03 s (256 µs/read; 0.23 M reads/minute).
+Processing single-end reads on 4 cores ...
 
 === Summary ===
 
@@ -117,6 +116,7 @@ Total written (filtered):         23,035 bp (92.7%)
 
 Sequence: CTGTCTCTTATA; Type: regular 3'; Length: 12; Trimmed: 58 times
 
+Minimum overlap: 1
 No. of allowed errors:
 1-9 bp: 0; 10-12 bp: 1
 

--- a/tools/trim_galore/test-data/paired_example_results2gz.txt
+++ b/tools/trim_galore/test-data/paired_example_results2gz.txt
@@ -3,13 +3,13 @@ SUMMARISING RUN PARAMETERS
 ==========================
 Input filename: input_1.fastq.gz
 Trimming mode: paired-end
-Trim Galore version: 0.6.7
-Cutadapt version: 3.4
-Python version: could not detect
+Trim Galore version: 0.6.10
+Cutadapt version: 5.0
+Python version: 3.12.10
 Number of cores used for trimming: 4
 Quality Phred score cutoff: 20
 Quality encoding type selected: ASCII+33
-Using Nextera adapter for trimming (count: 29). Second best hit was Illumina (count: 0)
+Using Nextera adapter for trimming (count: 29). Second best hit was smallRNA (count: 0)
 Adapter sequence: 'CTGTCTCTTATA' (Nextera Transposase sequence; auto-detected)
 Maximum trimming error rate: 0.1 (default)
 Minimum required adapter overlap (stringency): 1 bp
@@ -17,10 +17,9 @@ Minimum required sequence length for both reads before a sequence pair gets remo
 Output file will be GZIP compressed
 
 
-This is cutadapt 3.4 with Python 3.9.6
+This is cutadapt 5.0 with Python 3.12.10
 Command line parameters: -j 4 -e 0.1 -q 20 -O 1 -a CTGTCTCTTATA input_1.fastq.gz
-Processing reads on 4 cores in single-end mode ...
-Finished in 0.01 s (114 µs/read; 0.53 M reads/minute).
+Processing single-end reads on 4 cores ...
 
 === Summary ===
 
@@ -36,6 +35,7 @@ Total written (filtered):         23,339 bp (93.9%)
 
 Sequence: CTGTCTCTTATA; Type: regular 3'; Length: 12; Trimmed: 52 times
 
+Minimum overlap: 1
 No. of allowed errors:
 1-9 bp: 0; 10-12 bp: 1
 
@@ -86,13 +86,13 @@ SUMMARISING RUN PARAMETERS
 ==========================
 Input filename: input_2.fastq.gz
 Trimming mode: paired-end
-Trim Galore version: 0.6.7
-Cutadapt version: 3.4
-Python version: could not detect
+Trim Galore version: 0.6.10
+Cutadapt version: 5.0
+Python version: 3.12.10
 Number of cores used for trimming: 4
 Quality Phred score cutoff: 20
 Quality encoding type selected: ASCII+33
-Using Nextera adapter for trimming (count: 29). Second best hit was Illumina (count: 0)
+Using Nextera adapter for trimming (count: 29). Second best hit was smallRNA (count: 0)
 Adapter sequence: 'CTGTCTCTTATA' (Nextera Transposase sequence; auto-detected)
 Maximum trimming error rate: 0.1 (default)
 Minimum required adapter overlap (stringency): 1 bp
@@ -100,10 +100,9 @@ Minimum required sequence length for both reads before a sequence pair gets remo
 Output file will be GZIP compressed
 
 
-This is cutadapt 3.4 with Python 3.9.6
+This is cutadapt 5.0 with Python 3.12.10
 Command line parameters: -j 4 -e 0.1 -q 20 -O 1 -a CTGTCTCTTATA input_2.fastq.gz
-Processing reads on 4 cores in single-end mode ...
-Finished in 0.02 s (232 µs/read; 0.26 M reads/minute).
+Processing single-end reads on 4 cores ...
 
 === Summary ===
 
@@ -119,6 +118,7 @@ Total written (filtered):         23,035 bp (92.7%)
 
 Sequence: CTGTCTCTTATA; Type: regular 3'; Length: 12; Trimmed: 58 times
 
+Minimum overlap: 1
 No. of allowed errors:
 1-9 bp: 0; 10-12 bp: 1
 

--- a/tools/trim_galore/test-data/sanger_full_range_report_results1.txt
+++ b/tools/trim_galore/test-data/sanger_full_range_report_results1.txt
@@ -3,13 +3,13 @@ SUMMARISING RUN PARAMETERS
 ==========================
 Input filename: input_1.fastq
 Trimming mode: single-end
-Trim Galore version: 0.6.7
-Cutadapt version: 3.4
-Python version: could not detect
+Trim Galore version: 0.6.10
+Cutadapt version: 5.0
+Python version: 3.12.10
 Number of cores used for trimming: 4
 Quality Phred score cutoff: 20
 Quality encoding type selected: ASCII+33
-Unable to auto-detect most prominent adapter from the first specified file (count Nextera: 0, count smallRNA: 0, count Illumina: 0)
+Unable to auto-detect most prominent adapter from the first specified file (count smallRNA: 0, count Nextera: 0, count Illumina: 0)
 Defaulting to Illumina universal adapter ( AGATCGGAAGAGC ). Specify -a SEQUENCE to avoid this behavior).
 Adapter sequence: 'AGATCGGAAGAGC' (Illumina TruSeq, Sanger iPCR; default (inconclusive auto-detection))
 Maximum trimming error rate: 0.1 (default)
@@ -17,10 +17,9 @@ Minimum required adapter overlap (stringency): 1 bp
 Minimum required sequence length before a sequence gets removed: 20 bp
 
 
-This is cutadapt 3.4 with Python 3.9.6
+This is cutadapt 5.0 with Python 3.12.10
 Command line parameters: -j 4 -e 0.1 -q 20 -O 1 -a AGATCGGAAGAGC input_1.fastq
-Processing reads on 4 cores in single-end mode ...
-Finished in 0.01 s (5282 µs/read; 0.01 M reads/minute).
+Processing single-end reads on 4 cores ...
 
 === Summary ===
 
@@ -36,6 +35,7 @@ Total written (filtered):            167 bp (88.8%)
 
 Sequence: AGATCGGAAGAGC; Type: regular 3'; Length: 13; Trimmed: 1 times
 
+Minimum overlap: 1
 No. of allowed errors:
 1-9 bp: 0; 10-13 bp: 1
 

--- a/tools/trim_galore/test-data/sanger_full_range_report_results1gz.txt
+++ b/tools/trim_galore/test-data/sanger_full_range_report_results1gz.txt
@@ -3,13 +3,13 @@ SUMMARISING RUN PARAMETERS
 ==========================
 Input filename: input_1.fastq.gz
 Trimming mode: single-end
-Trim Galore version: 0.6.7
-Cutadapt version: 3.4
-Python version: could not detect
+Trim Galore version: 0.6.10
+Cutadapt version: 5.0
+Python version: 3.12.10
 Number of cores used for trimming: 4
 Quality Phred score cutoff: 20
 Quality encoding type selected: ASCII+33
-Unable to auto-detect most prominent adapter from the first specified file (count Illumina: 0, count Nextera: 0, count smallRNA: 0)
+Unable to auto-detect most prominent adapter from the first specified file (count Illumina: 0, count smallRNA: 0, count Nextera: 0)
 Defaulting to Illumina universal adapter ( AGATCGGAAGAGC ). Specify -a SEQUENCE to avoid this behavior).
 Adapter sequence: 'AGATCGGAAGAGC' (Illumina TruSeq, Sanger iPCR; default (inconclusive auto-detection))
 Maximum trimming error rate: 0.1 (default)
@@ -18,10 +18,9 @@ Minimum required sequence length before a sequence gets removed: 20 bp
 Output file will be GZIP compressed
 
 
-This is cutadapt 3.4 with Python 3.9.6
+This is cutadapt 5.0 with Python 3.12.10
 Command line parameters: -j 4 -e 0.1 -q 20 -O 1 -a AGATCGGAAGAGC input_1.fastq.gz
-Processing reads on 4 cores in single-end mode ...
-Finished in 0.01 s (5217 µs/read; 0.01 M reads/minute).
+Processing single-end reads on 4 cores ...
 
 === Summary ===
 
@@ -37,6 +36,7 @@ Total written (filtered):            167 bp (88.8%)
 
 Sequence: AGATCGGAAGAGC; Type: regular 3'; Length: 13; Trimmed: 1 times
 
+Minimum overlap: 1
 No. of allowed errors:
 1-9 bp: 0; 10-13 bp: 1
 

--- a/tools/trim_galore/trim_galore.xml
+++ b/tools/trim_galore/trim_galore.xml
@@ -486,7 +486,7 @@
             </conditional>
             <output name="trimmed_reads_pair1" file="paired_example_pair1_results2.fastqsanger" ftype="fastqsanger"/>
             <output name="trimmed_reads_pair2" file="paired_example_pair2_results2.fastqsanger" ftype="fastqsanger"/>
-            <output name="report_file" file="paired_example_results2.txt" ftype="txt" lines_diff="16" />
+            <output name="report_file" file="paired_example_results2.txt" ftype="txt" lines_diff="20" />
         </test>
         <test expect_num_outputs="3">
             <conditional name="singlePaired">
@@ -500,7 +500,7 @@
             </conditional>
             <output name="trimmed_reads_pair1" file="paired_example_pair1_results2.fastq.gz" ftype="fastqsanger.gz" decompress="true" />
             <output name="trimmed_reads_pair2" file="paired_example_pair2_results2.fastq.gz" ftype="fastqsanger.gz" decompress="true" />
-            <output name="report_file" file="paired_example_results2gz.txt" ftype="txt" lines_diff="16" />
+            <output name="report_file" file="paired_example_results2gz.txt" ftype="txt" lines_diff="20" />
         </test>
 
         <test expect_num_outputs="7">
@@ -520,7 +520,7 @@
                     <param name="retain_unpaired_select" value="retain_unpaired_output" />
                 </conditional>
             </conditional>
-            <output name="report_file" file="paired_collection_example_results3.txt" ftype="txt" lines_diff="16" />
+            <output name="report_file" file="paired_collection_example_results3.txt" ftype="txt" lines_diff="20" />
             <output_collection name="trimmed_reads_paired_collection" type="paired">
                 <element name="forward" file="paired_collection_example_pair1_results3.fastqsanger" ftype="fastqsanger"/>
                 <element name="reverse" file="paired_collection_example_pair2_results3.fastqsanger" ftype="fastqsanger"/>
@@ -548,7 +548,7 @@
                     <param name="retain_unpaired_select" value="retain_unpaired_output" />
                 </conditional>
             </conditional>
-            <output name="report_file" file="paired_collection_example_results3gz.txt" ftype="txt" lines_diff="18" />
+            <output name="report_file" file="paired_collection_example_results3gz.txt" ftype="txt" lines_diff="20" />
             <output_collection name="trimmed_reads_paired_collection" type="paired">
                 <element name="forward" file="paired_collection_example_pair1_results3.fastq.gz" ftype="fastqsanger.gz" decompress="true" />
                 <element name="reverse" file="paired_collection_example_pair2_results3.fastq.gz" ftype="fastqsanger.gz" decompress="true" />

--- a/tools/trim_galore/trim_galore.xml
+++ b/tools/trim_galore/trim_galore.xml
@@ -415,7 +415,7 @@
                 <param name="report" value="true" />
             </conditional>
             <output name="trimmed_reads_single" file="sanger_full_range_results1.fastqsanger" ftype="fastqsanger"/>
-            <output name="report_file" file="sanger_full_range_report_results1.txt" ftype="txt" lines_diff="12" />
+            <output name="report_file" file="sanger_full_range_report_results1.txt" ftype="txt" lines_diff="8" />
         </test>
         <test expect_num_outputs="2">
             <conditional name="singlePaired">
@@ -427,7 +427,7 @@
                 <param name="report" value="true" />
             </conditional>
             <output name="trimmed_reads_single" file="sanger_full_range_results1.fastq.gz" ftype="fastqsanger.gz" decompress="true" />
-            <output name="report_file" file="sanger_full_range_report_results1gz.txt" ftype="txt" lines_diff="12" />
+            <output name="report_file" file="sanger_full_range_report_results1gz.txt" ftype="txt" lines_diff="10" />
         </test>
 
         <test expect_num_outputs="1">
@@ -486,7 +486,7 @@
             </conditional>
             <output name="trimmed_reads_pair1" file="paired_example_pair1_results2.fastqsanger" ftype="fastqsanger"/>
             <output name="trimmed_reads_pair2" file="paired_example_pair2_results2.fastqsanger" ftype="fastqsanger"/>
-            <output name="report_file" file="paired_example_results2.txt" ftype="txt" lines_diff="24" />
+            <output name="report_file" file="paired_example_results2.txt" ftype="txt" lines_diff="16" />
         </test>
         <test expect_num_outputs="3">
             <conditional name="singlePaired">
@@ -500,7 +500,7 @@
             </conditional>
             <output name="trimmed_reads_pair1" file="paired_example_pair1_results2.fastq.gz" ftype="fastqsanger.gz" decompress="true" />
             <output name="trimmed_reads_pair2" file="paired_example_pair2_results2.fastq.gz" ftype="fastqsanger.gz" decompress="true" />
-            <output name="report_file" file="paired_example_results2gz.txt" ftype="txt" lines_diff="24" />
+            <output name="report_file" file="paired_example_results2gz.txt" ftype="txt" lines_diff="16" />
         </test>
 
         <test expect_num_outputs="7">
@@ -520,7 +520,7 @@
                     <param name="retain_unpaired_select" value="retain_unpaired_output" />
                 </conditional>
             </conditional>
-            <output name="report_file" file="paired_collection_example_results3.txt" ftype="txt" lines_diff="24" />
+            <output name="report_file" file="paired_collection_example_results3.txt" ftype="txt" lines_diff="16" />
             <output_collection name="trimmed_reads_paired_collection" type="paired">
                 <element name="forward" file="paired_collection_example_pair1_results3.fastqsanger" ftype="fastqsanger"/>
                 <element name="reverse" file="paired_collection_example_pair2_results3.fastqsanger" ftype="fastqsanger"/>
@@ -548,7 +548,7 @@
                     <param name="retain_unpaired_select" value="retain_unpaired_output" />
                 </conditional>
             </conditional>
-            <output name="report_file" file="paired_collection_example_results3gz.txt" ftype="txt" lines_diff="25" />
+            <output name="report_file" file="paired_collection_example_results3gz.txt" ftype="txt" lines_diff="18" />
             <output_collection name="trimmed_reads_paired_collection" type="paired">
                 <element name="forward" file="paired_collection_example_pair1_results3.fastq.gz" ftype="fastqsanger.gz" decompress="true" />
                 <element name="reverse" file="paired_collection_example_pair2_results3.fastq.gz" ftype="fastqsanger.gz" decompress="true" />

--- a/tools/trim_galore/trim_galore.xml
+++ b/tools/trim_galore/trim_galore.xml
@@ -415,7 +415,7 @@
                 <param name="report" value="true" />
             </conditional>
             <output name="trimmed_reads_single" file="sanger_full_range_results1.fastqsanger" ftype="fastqsanger"/>
-            <output name="report_file" file="sanger_full_range_report_results1.txt" ftype="txt" lines_diff="8" />
+            <output name="report_file" file="sanger_full_range_report_results1.txt" ftype="txt" lines_diff="13" />
         </test>
         <test expect_num_outputs="2">
             <conditional name="singlePaired">

--- a/tools/trim_galore/trim_galore.xml
+++ b/tools/trim_galore/trim_galore.xml
@@ -811,7 +811,7 @@ It is developed by Felix Krueger at the Babraham Institute.
     |
     | *option --amplicon*
 
-.. _Trim Galore!: http://www.bioinformatics.babraham.ac.uk/projects/trim_galore/
+.. _Trim Galore!: https://www.bioinformatics.babraham.ac.uk/projects/trim_galore/
 .. _Multi-tissue DNA methylation age predictor in mouse: https://genomebiology.biomedcentral.com/articles/10.1186/s13059-017-1203-5
 
     ]]></help>


### PR DESCRIPTION
version bump to 0.6.10 with updated tests; i tried to narrow down the diff checking a bit; each deviation seems to cause 2 hits (maybe because its the unified `diff -u`?), but some things can and should be variable (python version and number of cores, e.g.), and one line seems to randomly reorder itself (these vary in order: `(count smallRNA: 0, count Nextera: 0, count Illumina: 0)`)... but it may be too restrictive (other things might vary that i did not notice in my test runs; also will the underlying version of cutadapt change?)