### PR TITLE
Update data table references for LLM models

### DIFF
--- a/tools/llm_hub/llm_hub.xml
+++ b/tools/llm_hub/llm_hub.xml
@@ -2,7 +2,7 @@
     <description>Call any LLM</description>
     <macros>
         <import>macros.xml</import>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
         <token name="@PROFILE@">24.0</token>
     </macros>
     <requirements>
@@ -38,19 +38,19 @@ python '$__tool_directory__/llm_hub.py'
             </param>
             <when value="multimodal">
                 <param name="model" type="select" optional="false" label="Model" help="Select the model you want to use.">
-                    <options from_data_table="litellm">
+                    <options from_data_table="llm_models">
                         <filter type="static_value" column="2" value="multimodal"/>
                     </options>
-                    <validator message="No model annotation is available for LiteLLM" type="no_options"/>
+                    <validator message="No model annotation is available for LLM Hub" type="no_options"/>
                 </param>
                 <param name="context" type="data" multiple="true" optional="false" format="html,json,txt,jpg,png,gif" label="Context" max="500"/>
             </when>
             <when value="text">
                 <param name="model" type="select" optional="false" label="Model" help="Select the model you want to use.">
-                    <options from_data_table="litellm">
+                    <options from_data_table="llm_models">
                         <filter type="static_value" column="2" value="text"/>
                     </options>
-                    <validator message="No model annotation is available for LiteLLM" type="no_options"/>
+                    <validator message="No model annotation is available for LLM Hub" type="no_options"/>
                 </param>
                 <param name="context" type="data" multiple="true" optional="false" format="docx,html,json,pdf,txt" label="Context" max="500"/>
             </when>


### PR DESCRIPTION
An update that was not applied on https://github.com/bgruening/galaxytools/pull/1669. Change data table references from "litellm" to "llm_models".