### PR TITLE
add --no-version-check for salmon quant

### DIFF
--- a/tools/salmon/macros.xml
+++ b/tools/salmon/macros.xml
@@ -414,6 +414,7 @@
         #end if
 
         salmon quant
+            --no-version-check
             --index '$index_path'
             #if $quant_type.input.single_or_paired.single_or_paired_opts == 'single':
                 --libType ${quant_type.input.single_or_paired.libtype.strandedness}


### PR DESCRIPTION
The `salmon quant` command will check the latest salmon version, but when the network is poor, the check may fail and write the message  `Version Info Exception: server did not respond before timeout` to logs. This can cause the galaxy tool to fail.

<img width="2620" height="854" alt="image" src="https://github.com/user-attachments/assets/ac9d888a-faa3-47c8-8ea1-ffa146f51e35" />

Therefore, it's better to add --no-version-check to disable version checking: `salmon quant --no-version-check`
