### PR TITLE
bia-ftp make accession parameter mandatory in XML

### DIFF
--- a/tools/image_processing/bia-ftplinks/biaftplink.xml
+++ b/tools/image_processing/bia-ftplinks/biaftplink.xml
@@ -22,7 +22,7 @@
 ]]>
     </command>
     <inputs>
-        <param name="accession" type="text" label="The accession ID of BioImages-Core or BioStudies-JCB" help="for eg. S-BIAD570, S-JCBD-201309038"/>
+        <param name="accession" type="text" optional="false" label="The accession ID of BioImages-Core or BioStudies-JCB" help="for eg. S-BIAD570, S-JCBD-201309038"/>
         <param name="ftplink_output" type="boolean" label="Generate FTP links?" help="If set, a file containing FTP links associated with the accession will be generated." />
     </inputs>
     <outputs>


### PR DESCRIPTION
I skipped bumping the gx version

Fix https://github.com/FAIR-imaging/galaxy-image-community/issues/11