### PR TITLE
Update GitHub Actions deployment conditions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -366,8 +366,9 @@ jobs:
   deploy:
     name: Deploy
     needs: [setup, lint, combine_outputs]
-    if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) && github.repository_owner == 'bgruening' }}
+    if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
+    environment: toolshed-deployment
     strategy:
       matrix:
         python-version: ['3.11']
@@ -403,8 +404,9 @@ jobs:
   deploy-report:
     name: Report deploy status
     needs: [deploy]
-    if: ${{ always() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) && github.repository_owner == 'bgruening' }}
+    if: ${{ always() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) }}
     runs-on: ubuntu-latest
+    environment: toolshed-deployment
     steps:
     # report to the PR if deployment failed
     - name: Get PR object


### PR DESCRIPTION
Refine [deployment conditions](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/deploy-to-environment) in the GitHub Actions workflow by removing the repository owner check and adding an [environment](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments) specification for deployment.