### PR TITLE
Restrict number of GPUs

### DIFF
--- a/tools/parabricks/parabricks_fq2bam.xml
+++ b/tools/parabricks/parabricks_fq2bam.xml
@@ -2,7 +2,7 @@
     <description>Run GPU-bwa mem mapper</description>
     <macros>
         <token name="@TOOL_VERSION@">4.6.0-2</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@VERSION_SUFFIX@">2</token>
         <token name="@PROFILE@">24.2</token>
     </macros>
     <creator>


### PR DESCRIPTION
- `--bwa-normalized-queue-capacity 1` and `--num-gpus 1` may restrict the number of GPUs used on the EU
- `--gpuwrite` and `--gpusort` may improve performance on GPUs

https://docs.nvidia.com/clara/parabricks/latest/documentation/tooldocs/man_fq2bam.html#useful-options-for-performance

@bgruening 