### PR TITLE
Add GitHub Environment setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,3 +15,37 @@ inclusion.
 * Make sure you have added the necessary tests for your changes and they pass.
 * Open a [pull request](https://help.github.com/articles/using-pull-requests)
   with these changes.
+
+## Setting up GitHub Environment for Deployment (Maintainers Only)
+
+If you are a regular contributor working on a fork, you do **not** need to set this up. The deployment
+jobs will only run on the main upstream repository when code is merged to the `master` or `main` branch. 
+All other CI checks (linting, testing) will work normally on your fork without any special configuration.
+
+### Background
+
+This repository uses GitHub Environments instead of repository-level secrets
+for deployment. This provides better security through deployment protection rules and clearer
+separation of deployment credentials from general repository secrets.
+
+**This environment is only configured on the main upstream repository and should not be replicated on forks.**
+
+### Setup Instructions
+
+1. **Create the Environment**
+   - Go to your repository: `Settings` > `Environments`
+   - Click `New environment`
+   - Name it: `toolshed-deployment`
+
+2. **Add Required Secrets to the Environment**
+   
+   **IMPORTANT**: All secrets must be added to the `toolshed-deployment` **environment**,
+   not as repository-level secrets (Settings > Secrets and variables > Actions).
+   
+   Go to: `Settings` > `Environments` > `toolshed-deployment` > `Add Secret`
+   
+   Add each of the following secrets:
+   
+   - **TTS_API_KEY**: Your API key for TestToolShed
+   - **TS_API_KEY**: Your API key for ToolShed
+   - **PAT**: Personal Access Token with `repo` scope


### PR DESCRIPTION
ref: https://github.com/bgruening/galaxytools/pull/1720
Provide detailed instructions for maintainers on setting up the GitHub Environment for deployment. This includes creating the environment and adding the necessary secrets.