### PR TITLE
Update 3dtrees_overviews

### DIFF
--- a/tools/3dtrees_overviews/overviews.xml
+++ b/tools/3dtrees_overviews/overviews.xml
@@ -1,7 +1,7 @@
-<tool id="3dtrees_overviews" name="3D Trees Overview Generator" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="24.2">
+<tool id="3dtrees_overviews" name="3Dtrees: Overviews" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="24.2">
   <description>Generate 3D point cloud overview images from LAZ/LAS datasets</description>
   <macros>
-    <token name="@TOOL_VERSION@">1.1.0</token>
+    <token name="@TOOL_VERSION@">1.2.0</token>
     <token name="@VERSION_SUFFIX@">0</token>
   </macros>
   <requirements>


### PR DESCRIPTION
**Tool metadata and configuration updates:**
* Changed the tool name from "3D Trees Overview Generator" to "3Dtrees: Overviews" and updated the version from `1.1.0` to `1.2.0`.
* Changed the input parameter from a data collection (`collection_type="list"`) to a multi-file data input (`multiple="true"`), allowing users to select multiple LAZ files directly instead of creating a collection.

**Parameter and default value adjustments:**
* Reduced the default value for `max_total_points` from 50,000,000 to 40,000,000.
* Changed the default color map from "Turbo" to "Viridis" by updating the selected option.

**Test case update:**
* Updated the test input to match the new input parameter format, using a direct file input instead of a collection.