### PR TITLE
Update 3dtrees_overviews to exclude file extension

### DIFF
--- a/tools/3dtrees_overviews/overviews.xml
+++ b/tools/3dtrees_overviews/overviews.xml
@@ -2,7 +2,7 @@
   <description>Generate 3D point cloud overview images from LAZ/LAS datasets</description>
   <macros>
     <token name="@TOOL_VERSION@">1.2.0</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
   </macros>
   <requirements>
     <container type="docker">ghcr.io/3dtrees-earth/tool_overviews:@TOOL_VERSION@</container>
@@ -64,10 +64,10 @@
   </inputs>
   <outputs>
     <collection name="top_views" type="list" label="Top View Images">
-      <discover_datasets pattern="(?P&lt;name&gt;top_view_.*\.png)" directory="./output_dir/" recurse="false" visible="false" format="png"/>
+      <discover_datasets pattern="(?P&lt;name&gt;top_view_.*)\.png" directory="./output_dir/" recurse="false" visible="false" format="png"/>
     </collection>
     <collection name="section_views" type="list" label="Section View Images">
-      <discover_datasets pattern="(?P&lt;name&gt;section_.*\.png)" directory="./output_dir/" recurse="false" visible="false" format="png"/>
+      <discover_datasets pattern="(?P&lt;name&gt;section_.*)\.png" directory="./output_dir/" recurse="false" visible="false" format="png"/>
     </collection>
   </outputs>
   <tests>
@@ -81,7 +81,7 @@
       <param name="cmap" value="viridis"/>
       <param name="camera_distance" value="25.0"/>
       <output_collection name="top_views" type="list">
-        <element name="top_view_00.png" ftype="png">
+        <element name="top_view_00" ftype="png">
           <assert_contents>
             <has_size size="160000" delta="100000"/>
           </assert_contents>


### PR DESCRIPTION
This pull request makes minor updates to the `overviews.xml` configuration for the 3D point cloud overview tool. The changes primarily address versioning and dataset discovery patterns to improve compatibility and output handling.

Most important changes:

**Versioning:**
* Updated the `@VERSION_SUFFIX@` macro value from `0` to `1` to reflect a new tool version.

**Dataset discovery and output handling:**
* Adjusted the regular expressions in the `discover_datasets` patterns for both `top_views` and `section_views` collections to exclude the `.png` extension from the captured name group, improving dataset naming consistency.
* Updated the test output element name in the `top_views` collection to match the new pattern (removed `.png` from the element name).