### PR TITLE
Update 3dtrees_potree

### DIFF
--- a/tools/3dtrees_potree/3dtrees_potree.xml
+++ b/tools/3dtrees_potree/3dtrees_potree.xml
@@ -23,11 +23,12 @@
         $keep_chunks
         $no_chunking
         $no_indexing
+        $generate_page
         #if $generate_page
-            --generate-page '$generate_page' &&
+            &&
 
             ## Setup HTML with extra files for Galaxy viewing
-            cp output/'$generate_page'.html '$viewer_html' &&
+            cp output/potree-vis.html '$viewer_html' &&
             mkdir -p '$viewer_html.files_path' &&
             cp -r /opt/PotreeConverter/resources/page_template/libs '$viewer_html.files_path/' &&
             cp -r output/pointclouds '$viewer_html.files_path/' &&
@@ -38,6 +39,7 @@
     </command>
     <inputs>
         <param name="input" type="data" format="laz" multiple="true" label="Point Cloud Files" help="Input LAS/LAZ files to convert to Potree format" />
+        <param argument="--generate-page" type="boolean" truevalue="-p potree-vis" falsevalue="" checked="false" label="Generate interactive Viewer" help="Generate a ready-to-use HTML viewer page for in-Galaxy visualization" />
         <param argument="--encoding" type="select" label="Encoding" help="Compression encoding for output">
             <option value="BROTLI" selected="true">Brotli</option>
             <option value="UNCOMPRESSED">Uncompressed</option>
@@ -53,13 +55,10 @@
         <param argument="--keep-chunks" type="boolean" truevalue="--keep-chunks" falsevalue="" checked="false" label="Keep Chunks" help="Skip deleting temporary chunks during conversion" />
         <param argument="--no-chunking" type="boolean" truevalue="--no-chunking" falsevalue="" checked="false" label="No Chunking" help="Disable chunking phase" />
         <param argument="--no-indexing" type="boolean" truevalue="--no-indexing" falsevalue="" checked="false" label="No Indexing" help="Disable indexing phase" />
-        <param name="generate_page" type="text" optional="true" label="Generate Page" help="Generate a ready-to-use web page with the given name (e.g., 'viewer'). Leave empty to skip page generation.">
-            <validator type="regex" message="Only letters are allowed">^[a-zA-Z,]</validator>
-        </param>
     </inputs>
     <outputs>
         <!-- HTML viewer for in-Galaxy viewing (when generate_page is specified) -->
-        <data name="viewer_html" format="html" label="Potree Visualization: ${generate_page}">
+        <data name="viewer_html" format="html" label="Potree Visualization">
             <filter>generate_page</filter>
         </data>
         <!-- Collection output - discovers files in output directory -->
@@ -73,11 +72,11 @@
     <tests>
         <test expect_num_outputs="2">
             <param name="input" value="mikro.laz" ftype="laz"/>
-            <param name="generate_page" value="test"/>
+            <param name="generate_page" value="true"/>
             <!-- HTML viewer for Galaxy -->
             <output name="viewer_html" ftype="html">
                 <assert_contents>
-                    <has_text text='Potree.loadPointCloud("./pointclouds/test/metadata.json", "test"'/>
+                    <has_text text='Potree.loadPointCloud("./pointclouds/potree-vis/metadata.json", "potree-vis"'/>
                 </assert_contents>
             </output>
             <!-- Collection output for octree data -->


### PR DESCRIPTION
This pull request makes several improvements to the `3dtrees_potree` Galaxy tool, focusing on better integration of the Potree HTML viewer for web visualization and clarifying output handling. The main changes provide a dedicated HTML viewer output for in-Galaxy visualization, update the test suite to reflect this new output, and enhance documentation for users.

**Enhancements to output handling and visualization:**

* Added a new `viewer_html` output that provides an interactive Potree HTML viewer for Galaxy users, including necessary extra files (`libs/` and `pointclouds/`) for proper visualization. [[1]](diffhunk://#diff-48eb42865b11a5f301a1f15923fe09d41d6177896198021cbc22c71706a92694L27-R34) [[2]](diffhunk://#diff-48eb42865b11a5f301a1f15923fe09d41d6177896198021cbc22c71706a92694R61-R84)
* Updated the output collection to remove direct HTML output from the collection and instead provide it as a separate output, ensuring clarity and easier access for users.

**Testing and validation improvements:**

* Modified the test suite to expect the new `viewer_html` output and validate its contents, ensuring that the HTML viewer is correctly generated and includes the required references to point cloud data. [[1]](diffhunk://#diff-48eb42865b11a5f301a1f15923fe09d41d6177896198021cbc22c71706a92694R61-R84) [[2]](diffhunk://#diff-48eb42865b11a5f301a1f15923fe09d41d6177896198021cbc22c71706a92694L88-L92)

**Documentation updates:**

* Revised the help section to clarify the purpose and contents of the new HTML viewer output, including notes about its intended use within Galaxy and instructions for local viewing.

**Versioning:**

* Updated the `@VERSION_SUFFIX@` macro from `0` to `1` to reflect the new tool version.