### PR TITLE
de.NBI credits for kMetaShot wrapper

### DIFF
--- a/tools/kmetashot/kmetashot.xml
+++ b/tools/kmetashot/kmetashot.xml
@@ -19,11 +19,13 @@
                        email="giuseppe.defazio@uniba.it"
                        identifier="https://orcid.org/0000-0002-9356-5224"/>
         <organization name="de.NBI"
-                                identifier="https://ror.org/01vmpm840"
+                      identifier="https://ror.org/01vmpm840"
                       url="https://www.denbi.de/" />
         <organization name="ELIXIR-DE"
+                      identifier="https://ror.org/056mykw55"
                       url="https://elixir-de.org/" />
         <organization name="UniBA"
+                      identifier="https://ror.org/027ynra39"
                       url="https://www.uniba.it/" />
     </creator>
     <requirements>


### PR DESCRIPTION
From @paulzierep suggestion. It is needed to add credits to de.NBI because provided VM for kMS wrapper testing and serving.