### PR TITLE
Update 3dtrees_smart_tile to version 1.0.2

### DIFF
--- a/tools/3dtrees_smart_tile/smart_tile.xml
+++ b/tools/3dtrees_smart_tile/smart_tile.xml
@@ -1,7 +1,7 @@
 <tool id="3dtrees_smart_tile" name="3DTrees: SmartTile" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="24.2">
     <description>Subsampling, tiling, merging and matching of (multiple) point clouds</description>
     <macros>
-        <token name="@TOOL_VERSION@">1.0.1</token>
+        <token name="@TOOL_VERSION@">1.0.2</token>
         <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>


### PR DESCRIPTION
This pull request makes a minor update to the `3dtrees_smart_tile` tool by incrementing its version number from 1.0.1 to 1.0.2 in the `smart_tile.xml` file.