### PR TITLE
Fix citation DOI in cellpose.xml

### DIFF
--- a/tools/cellpose/cellpose.xml
+++ b/tools/cellpose/cellpose.xml
@@ -2,7 +2,7 @@
     <description>with Cellpose 3</description>
     <macros>
         <token name="@TOOL_VERSION@">3.1.0</token>
-        <token name="@VERSION_SUFFIX@">2</token>
+        <token name="@VERSION_SUFFIX@">3</token>
     </macros>
     <requirements>
         <container type="docker">quay.io/biocontainers/cellpose:@TOOL_VERSION@</container>


### PR DESCRIPTION
Previously, the wrapper referenced this paper for citation:

> Stringer, C., Wang, T., Michaelos, M., & Pachitariu, M. (2020). Cellpose: a generalist algorithm for cellular segmentation. https://doi.org/10.1101/2020.02.02.931238

This, however, is the Cellpose v1 paper.

This wrapper is for Cellpose v3 and _I think_ the correct paper is: https://www.nature.com/articles/s41592-025-02595-5

---

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
