### PR TITLE
Add refresh_on_change attribute to header param to cut.xml

### DIFF
--- a/tools/text_processing/text_processing/cut.xml
+++ b/tools/text_processing/text_processing/cut.xml
@@ -44,7 +44,7 @@
                     <option value="|">Pipe</option>
                 </param>
                 <conditional name="colnames_option">
-                    <param name="header" type="select" label="Is there a header for the data's columns ?">
+                    <param name="header" type="select" label="Is there a header for the data's columns ?" refresh_on_change="true">
                         <option value="Y">Yes</option>
                         <option value="N" selected="true">No</option>
                     </param>


### PR DESCRIPTION
This is needed to reliably provide the column names in the column selection menu, otherwise it will just display the columns of the previously selected dataset.

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
