### PR TITLE
Image Magick conversion: fix missing font error for svg conversion

### DIFF
--- a/tools/image_processing/imagemagick/convert.xml
+++ b/tools/image_processing/imagemagick/convert.xml
@@ -1,4 +1,4 @@
-<tool id="imagemagick_image_convert" name="Convert image format" version="@TOOL_VERSION@+galaxy2" profile="22.05">
+<tool id="imagemagick_image_convert" name="Convert image format" version="@TOOL_VERSION@+galaxy3" profile="22.05">
     <description>with ImageMagick</description>
     <macros>
         <import>macros.xml</import>
@@ -12,7 +12,11 @@
     #else:
         #set $trans_options = ''
     #end if
-    magick 
+
+    fontfile=\$(fc-list | grep DejaVuSans.ttf | head -n 1 | cut -d: -f1) &&
+    echo "Using font file: \$fontfile" &&
+    magick
+        \$(if [ -n "\$fontfile" ]; then echo "-font \$fontfile"; fi)
         'input.${input.ext}'
         -resize ${resize}%
         +depth


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
