### PR TITLE
Fix Tiara wrapper when outputs are missing

### DIFF
--- a/tools/tiara/macros.xml
+++ b/tools/tiara/macros.xml
@@ -1,6 +1,7 @@
 <macros>
     <token name="@TOOL_VERSION@">1.0.3</token>
-    <token name="@VERSION_SUFFIX@">galaxy0</token>
+    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@PROFILE@">25.1</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">tiara</requirement>

--- a/tools/tiara/macros.xml
+++ b/tools/tiara/macros.xml
@@ -5,7 +5,6 @@
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">tiara</requirement>
-            <requirement type="package" version="3.8">python</requirement>
         </requirements>
     </xml>
     <xml name="biotools">

--- a/tools/tiara/tiara.xml
+++ b/tools/tiara/tiara.xml
@@ -1,4 +1,4 @@
-<tool id="tiara" name="tiara" version="@TOOL_VERSION@+galaxy2" profile="21.05">
+<tool id="tiara" name="tiara" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>Deep-learning-based approach for identification of eukaryotic sequences in the metagenomic data </description>
     <macros>
         <import>macros.xml</import>

--- a/tools/tiara/tiara.xml
+++ b/tools/tiara/tiara.xml
@@ -7,7 +7,6 @@
     <expand macro="requirements"/>
     <command detect_errors="exit_code"><![CDATA[ 
         mkdir -p ./txt &&
-        mkdir -p ./fasta &&
 
         tiara 
         -t \${GALAXY_SLOTS:-4} 
@@ -33,9 +32,6 @@
         #if $taxonomy_filter
             --tf #for $tf in $taxonomy_filter
                 $tf
-            #end for
-            #for $tf in $taxonomy_filter
-              && find ./txt/ -name ${tf}*.dat -exec mv {} ./fasta/${tf}.fasta ';'
             #end for
         #end if
 
@@ -81,10 +77,10 @@
     </inputs>
     <outputs>
         <collection name="output_fasta" type="list" label="${tool.name} on ${on_string}: Fasta Output">
-            <discover_datasets pattern="__name_and_ext__"  ext="fasta" directory="fasta" />
+            <discover_datasets pattern="(?P&lt;designation&gt;[^_]+)_dataset_.*\.dat$"  format="fasta" directory="txt" />
         </collection>
         <collection name="output_txt" type="list" label="${tool.name} on ${on_string}: Classified sequences in txt">
-            <discover_datasets pattern="__name_and_ext__"  ext="txt" directory="txt" />
+            <discover_datasets pattern="(?P&lt;designation&gt;.+)\.txt$"  format="txt" directory="txt" />
         </collection>
     </outputs>
     <tests>
@@ -92,7 +88,7 @@
             <param name="input" value="plast_fr.fasta.gz"/>
             <param name="taxonomy_filter" value="pla"/>
             <output_collection name="output_fasta" type="list">
-                <element name="pla" file="pla" ftype="fasta" />
+                <element name="plastid" file="pla" ftype="fasta" />
             </output_collection>
             <output_collection name="output_txt" type="list">
                 <element name="main_result" file="main_result01.txt" ftype="txt"/>
@@ -102,9 +98,9 @@
             <param name="input" value="sample_all.fasta"/>
             <param name="taxonomy_filter" value="euk,bac,arc,unk"/>
             <output_collection name="output_fasta" type="list">
-                <element name="arc" file="arc" ftype="fasta" />
-                <element name="bac" file="bac" ftype="fasta" />
-                <element name="euk" file="euk" ftype="fasta" />
+                <element name="archaea" file="arc" ftype="fasta" />
+                <element name="bacteria" file="bac" ftype="fasta" />
+                <element name="eukarya" file="euk" ftype="fasta" />
             </output_collection>
             <output_collection name="output_txt" type="list">
                 <element name="main_result" file="main_result02.txt" ftype="txt" />
@@ -118,7 +114,7 @@
             <param name="cutoff_stage2" value="0.60"/>
             <param name="probabilities" value="true"/>
             <output_collection name="output_fasta" type="list">
-                <element name="euk" file="euk" ftype="fasta" />
+                <element name="eukarya" file="euk" ftype="fasta" />
             </output_collection>
             <output_collection name="output_txt" type="list">
                 <element name="main_result" file="main_result03.txt" ftype="txt" />

--- a/tools/tiara/tiara.xml
+++ b/tools/tiara/tiara.xml
@@ -1,4 +1,4 @@
-<tool id="tiara" name="tiara" version="@TOOL_VERSION@+galaxy1" profile="21.05">
+<tool id="tiara" name="tiara" version="@TOOL_VERSION@+galaxy2" profile="21.05">
     <description>Deep-learning-based approach for identification of eukaryotic sequences in the metagenomic data </description>
     <macros>
         <import>macros.xml</import>
@@ -6,11 +6,13 @@
     <expand macro="biotools"/>
     <expand macro="requirements"/>
     <command detect_errors="exit_code"><![CDATA[ 
-        mkdir ./results/ &&
+        mkdir -p ./txt &&
+        mkdir -p ./fasta &&
+
         tiara 
         -t \${GALAXY_SLOTS:-4} 
         -i '$input' 
-        -o ./results/main_result.txt
+        -o ./txt/main_result.txt
 
         #if $probabilities
             --pr '$probabilities'
@@ -33,20 +35,20 @@
                 $tf
             #end for
             #for $tf in $taxonomy_filter
-              && ls -l ./results/
-              &&  mv ./results/${tf}*.dat ./results/${tf}.fasta
+              && find ./txt/ -name ${tf}*.dat -exec mv {} ./fasta/${tf}.fasta ';'
             #end for
         #end if
 
     ]]></command>
     <inputs>
         <param name="input" type="data" format="fasta" label="input fasta,fasta.gz file"/>
-        <param name="taxonomy_filter" type="select" multiple="true" optional="true" label="Write sequences to fasta,fasta.gz files specified in the arguments to this option." help="all refers to all classes present in input fasta (to separate fasta files).">
+        <param name="taxonomy_filter" type="select" multiple="true" optional="true" label="Write sequences to fasta,fasta.gz files specified in the arguments to this option." help="Select one or more target types of sequences to write to separate FASTA files.">
             <option value="mit">mitochondria</option>
             <option value="pla">plastid</option>
             <option value="bac">bacteria</option>
-            <option value="arc">archea</option>
+            <option value="arc">archaea</option>
             <option value="euk">eukarya</option>
+            <option value="unk">unknown</option>
         </param>
         <param argument="probabilities" type="boolean" truevalue="--pr" falsevalue="" checked="false" label="Add probabilities of individual classes for each sequence."/>
         <param argument="min_len" type="integer" value="3000" min="1000" optional="true" label="Minimum length of a sequence. Default: 3000 bp." help="Specify the desired minimum length in base pairs.Default value is 3000 bp and we do not recommend classifying sequences shorter than 1000 bp. "/>
@@ -78,38 +80,47 @@
         </section>
     </inputs>
     <outputs>
-        <collection name="output" type="list" label="${tool.name} on ${on_string}: classified sequences in txt and Fasta Output">
-            <discover_datasets pattern="__name_and_ext__"  ext="fasta,txt" directory="results" />
+        <collection name="output_fasta" type="list" label="${tool.name} on ${on_string}: Fasta Output">
+            <discover_datasets pattern="__name_and_ext__"  ext="fasta" directory="fasta" />
+        </collection>
+        <collection name="output_txt" type="list" label="${tool.name} on ${on_string}: Classified sequences in txt">
+            <discover_datasets pattern="__name_and_ext__"  ext="txt" directory="txt" />
         </collection>
     </outputs>
     <tests>
-        <test expect_num_outputs="1">
+        <test expect_num_outputs="2">
             <param name="input" value="plast_fr.fasta.gz"/>
             <param name="taxonomy_filter" value="pla"/>
-            <output_collection name="output" type="list">
-                <element name="main_result" file="main_result01.txt" ftype="txt"/>
+            <output_collection name="output_fasta" type="list">
                 <element name="pla" file="pla" ftype="fasta" />
             </output_collection>
+            <output_collection name="output_txt" type="list">
+                <element name="main_result" file="main_result01.txt" ftype="txt"/>
+            </output_collection>
         </test>
-        <test expect_num_outputs="1">
+        <test expect_num_outputs="2">
             <param name="input" value="sample_all.fasta"/>
-            <param name="taxonomy_filter" value="euk,bac,arc"/>
-            <output_collection name="output" type="list">
+            <param name="taxonomy_filter" value="euk,bac,arc,unk"/>
+            <output_collection name="output_fasta" type="list">
                 <element name="arc" file="arc" ftype="fasta" />
                 <element name="bac" file="bac" ftype="fasta" />
                 <element name="euk" file="euk" ftype="fasta" />
+            </output_collection>
+            <output_collection name="output_txt" type="list">
                 <element name="main_result" file="main_result02.txt" ftype="txt" />
             </output_collection>
         </test>
-        <test expect_num_outputs="1">
+        <test expect_num_outputs="2">
             <param name="input" value="eukarya_fr.fasta"/>
             <param name="taxonomy_filter" value="euk"/>
             <param name="min_len" value="5000"/>
             <param name="cutoff_stage1" value="0.65"/>
             <param name="cutoff_stage2" value="0.60"/>
             <param name="probabilities" value="true"/>
-            <output_collection name="output" type="list">
+            <output_collection name="output_fasta" type="list">
                 <element name="euk" file="euk" ftype="fasta" />
+            </output_collection>
+            <output_collection name="output_txt" type="list">
                 <element name="main_result" file="main_result03.txt" ftype="txt" />
             </output_collection>
         </test>

--- a/tools/tiara/tiara.xml
+++ b/tools/tiara/tiara.xml
@@ -29,8 +29,8 @@
             --k1 $advanced_options.advance.first_stage_kmer
             --k2 $advanced_options.advance.second_stage_kmer
         #end if
-        #if $taxonomy_filter
-            --tf #for $tf in $taxonomy_filter
+        #if $fasta_output.produce_fasta == "yes"
+            --tf #for $tf in $fasta_output.taxonomy_filter
                 $tf
             #end for
         #end if
@@ -38,14 +38,24 @@
     ]]></command>
     <inputs>
         <param name="input" type="data" format="fasta" label="input fasta,fasta.gz file"/>
-        <param name="taxonomy_filter" type="select" multiple="true" optional="true" label="Write sequences to fasta,fasta.gz files specified in the arguments to this option." help="Select one or more target types of sequences to write to separate FASTA files.">
-            <option value="mit">mitochondria</option>
-            <option value="pla">plastid</option>
-            <option value="bac">bacteria</option>
-            <option value="arc">archaea</option>
-            <option value="euk">eukarya</option>
-            <option value="unk">unknown</option>
-        </param>
+        <conditional name="fasta_output">
+            <param name="produce_fasta" type="select" label="Produce split FASTA output?" help="Select Yes to write classified sequences for selected groups as separate FASTA outputs. By default, no FASTA files are produced and only the main classification table and log are generated.">
+                <option value="no" selected="true">No</option>
+                <option value="yes">Yes</option>
+            </param>
+            <when value="yes">
+                <param name="taxonomy_filter" type="select" multiple="true" label="Select sequence types">
+                    <option value="mit">mitochondria</option>
+                    <option value="pla">plastid</option>
+                    <option value="bac">bacteria</option>
+                    <option value="arc">archaea</option>
+                    <option value="euk">eukarya</option>
+                    <option value="unk">unknown</option>
+                </param>
+            </when>
+            <when value="no"/>
+        </conditional>
+
         <param argument="probabilities" type="boolean" truevalue="--pr" falsevalue="" checked="false" label="Add probabilities of individual classes for each sequence."/>
         <param argument="min_len" type="integer" value="3000" min="1000" optional="true" label="Minimum length of a sequence. Default: 3000 bp." help="Specify the desired minimum length in base pairs.Default value is 3000 bp and we do not recommend classifying sequences shorter than 1000 bp. "/>
         <param argument="cutoff_stage1" type="float" value="0.65" min="0.5" max="1" optional="true" label="Probability threshold for the first stage." help="Probability threshold needed for classification in the first stage. Default: 0.65." />
@@ -77,38 +87,47 @@
     </inputs>
     <outputs>
         <collection name="output_fasta" type="list" label="${tool.name} on ${on_string}: Fasta Output">
+            <filter>fasta_output['produce_fasta'] == 'yes'</filter>
             <discover_datasets pattern="(?P&lt;designation&gt;[^_]+)_dataset_.*\.dat$"  format="fasta" directory="txt" />
         </collection>
-        <collection name="output_txt" type="list" label="${tool.name} on ${on_string}: Classified sequences in txt">
-            <discover_datasets pattern="(?P&lt;designation&gt;.+)\.txt$"  format="txt" directory="txt" />
-        </collection>
+        <data name="main_result" format="tabular" from_work_dir="txt/main_result.txt" label="${tool.name} on ${on_string}: main result" />
+        <data name="log_result" format="txt" from_work_dir="txt/log_main_result.txt" label="${tool.name} on ${on_string}: log" />
     </outputs>
     <tests>
-        <test expect_num_outputs="2">
+        <test expect_num_outputs="3">
             <param name="input" value="plast_fr.fasta.gz"/>
-            <param name="taxonomy_filter" value="pla"/>
+            <param name="fasta_output|produce_fasta" value="yes"/>
+            <param name="fasta_output|taxonomy_filter" value="pla"/>
             <output_collection name="output_fasta" type="list">
                 <element name="plastid" file="pla" ftype="fasta" />
             </output_collection>
-            <output_collection name="output_txt" type="list">
-                <element name="main_result" file="main_result01.txt" ftype="txt"/>
-            </output_collection>
+            <output name="main_result" file="main_result01.txt" ftype="tabular" />
+            <output name="log_result" ftype="txt">
+                <assert_contents>
+                    <has_text text="First iteration statistics" />
+                </assert_contents>
+            </output>
         </test>
-        <test expect_num_outputs="2">
+        <test expect_num_outputs="3">
             <param name="input" value="sample_all.fasta"/>
-            <param name="taxonomy_filter" value="euk,bac,arc,unk"/>
+            <param name="fasta_output|produce_fasta" value="yes"/>
+            <param name="fasta_output|taxonomy_filter" value="euk,bac,arc,unk"/>
             <output_collection name="output_fasta" type="list">
                 <element name="archaea" file="arc" ftype="fasta" />
                 <element name="bacteria" file="bac" ftype="fasta" />
                 <element name="eukarya" file="euk" ftype="fasta" />
             </output_collection>
-            <output_collection name="output_txt" type="list">
-                <element name="main_result" file="main_result02.txt" ftype="txt" />
-            </output_collection>
+            <output name="main_result" file="main_result02.txt" ftype="tabular" />
+            <output name="log_result" ftype="txt">
+                <assert_contents>
+                    <has_text text="Models used:" />
+                </assert_contents>
+            </output>
         </test>
-        <test expect_num_outputs="2">
+        <test expect_num_outputs="3">
             <param name="input" value="eukarya_fr.fasta"/>
-            <param name="taxonomy_filter" value="euk"/>
+            <param name="fasta_output|produce_fasta" value="yes"/>
+            <param name="fasta_output|taxonomy_filter" value="euk"/>
             <param name="min_len" value="5000"/>
             <param name="cutoff_stage1" value="0.65"/>
             <param name="cutoff_stage2" value="0.60"/>
@@ -116,9 +135,12 @@
             <output_collection name="output_fasta" type="list">
                 <element name="eukarya" file="euk" ftype="fasta" />
             </output_collection>
-            <output_collection name="output_txt" type="list">
-                <element name="main_result" file="main_result03.txt" ftype="txt" />
-            </output_collection>
+            <output name="main_result" file="main_result03.txt" ftype="tabular" />
+            <output name="log_result" ftype="txt">
+                <assert_contents>
+                    <has_text text="Hyperparameters:" />
+                </assert_contents>
+            </output>
         </test>
     </tests>
     <help><![CDATA[


### PR DESCRIPTION
@wm75 @bgruening following the #1808.

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
