### PR TITLE
Update 3Dtrees SmartTile tool to version 2.0.1

### DIFF
--- a/tools/3dtrees_smart_tile/smart_tile.xml
+++ b/tools/3dtrees_smart_tile/smart_tile.xml
@@ -4,7 +4,10 @@
         <token name="@TOOL_VERSION@">2.0.1</token>
         <token name="@VERSION_SUFFIX@">0</token>
         <xml name="produce_merged_file_param">
-            <param argument="--produce-merged-file" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Also write one merged output (LAZ)" help="If enabled (default), produce a single merged LAZ in addition to the per-file outputs."/>
+            <param name="produce_merged_file" type="select" label="Also write one merged output (LAZ)" help="If enabled (default), produce a single merged LAZ in addition to the per-file outputs.">
+                <option value="False">No</option>
+                <option value="True" selected="true">Yes</option>
+            </param>
         </xml>
         <xml name="merge_enrichment_conditional">
             <conditional name="merge_enrichment_mode">

--- a/tools/3dtrees_smart_tile/smart_tile.xml
+++ b/tools/3dtrees_smart_tile/smart_tile.xml
@@ -1,7 +1,7 @@
 <tool id="3dtrees_smart_tile" name="3DTrees: SmartTile" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="24.2">
     <description>Create COPC tiles, subsample outputs, filter border overlap, and remap prediction dimensions</description>
     <macros>
-        <token name="@TOOL_VERSION@">2.0.0</token>
+        <token name="@TOOL_VERSION@">2.0.1</token>
         <token name="@VERSION_SUFFIX@">0</token>
         <xml name="produce_merged_file_param">
             <param argument="--produce-merged-file" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Also write one merged output (LAZ)" help="If enabled (default), produce a single merged LAZ in addition to the per-file outputs."/>
@@ -59,6 +59,7 @@
                 --resolution-1 '$operation.resolution_1'
                 --resolution-2 '$operation.resolution_2'
                 --output-copc-res1 $operation.output_copc_res1
+                --output-copc-res2 $operation.output_copc_res2
                 --dimension-reduction $operation.dimension_reduction
                 --chunk-size '$operation.chunk_size'
                 --num-spatial-chunks \${GALAXY_SLOTS:-4}
@@ -229,6 +230,7 @@
                 <param argument="--resolution-1" type="float" min="0.001" max="1.0" value="0.01" label="Subsample resolution 1 (m)" help="First subsampling resolution, in meters."/>
                 <param argument="--resolution-2" type="float" min="0.001" max="1.0" value="0.1" label="Subsample resolution 2 (m)" help="Second subsampling resolution, in meters."/>
                 <param argument="--output-copc-res1" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Write resolution 1 as COPC (.copc.laz)" help="If enabled (default), the first subsampled output collection is written as COPC LAZ (`*.copc.laz`). If disabled, it is written as standard LAZ (`*.laz`). This does not affect the internal COPC-normalized source cache."/>
+                <param argument="--output-copc-res2" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Write resolution 2 as COPC (.copc.laz)" help="If enabled, the second subsampled output collection is written as COPC LAZ (`*.copc.laz`). If disabled (default), it is written as standard LAZ (`*.laz`). This matches the new SmartTile res2 COPC output option."/>
                 <param argument="--dimension-reduction" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Reduce dimensions in subsampled outputs" help="If enabled (default), subsampled outputs are written with a minimal LAS schema (smaller files). The initial source-to-COPC normalization step still preserves all input dimensions."/>
                 <param argument="--chunk-size" type="integer" min="100000" max="200000000" value="20000000" label="Chunk size (points)" help="Performance knob. Controls chunked reads used during COPC normalization and later spatial slicing steps."/>
             </when>
@@ -363,7 +365,7 @@
             <output_collection name="output_subsampled_res2" type="list" count="1"/>
             <output name="output_tiling_preview">
                 <assert_contents>
-                    <has_image_center_of_mass center_of_mass="1813, 1768" eps="100"/>
+                    <has_image_center_of_mass center_of_mass="1974, 1785" eps="100"/>
                 </assert_contents>
             </output>
             <output name="output_tile_bounds_json">
@@ -449,6 +451,7 @@
 - It then creates overlapping tiles and writes two subsampled output collections.
 - `Reduce dimensions in subsampled outputs` only affects the subsampled outputs, not the internal COPC cache.
 - `Write resolution 1 as COPC (.copc.laz)` only affects the first subsampled output collection (default: enabled).
+- `Write resolution 2 as COPC (.copc.laz)` only affects the second subsampled output collection (default: disabled).
 
 **Filter**
 


### PR DESCRIPTION
Adding new output option for resolution 2 as COPC. Adjusted default settings and updated center of mass for output preview.

FOR CONTRIBUTOR:
* [X] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [X] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
