### PR TITLE
Fix `no_interp` parameter in Cellpose-SAM wrapper

### DIFF
--- a/tools/cellpose_v4/.shed.yml
+++ b/tools/cellpose_v4/.shed.yml
@@ -10,4 +10,4 @@ long_description: |
     Cellpose-SAM: cell and nucleus segmentation with superhuman generalization. It can be optimized for your own data, applied in 3D, works on images with shot noise, (an)isotropic blur, undersampling, contrast inversions, regardless of channel order and object sizes.
 auto_tool_repositories:
   name_template: "{{ tool_id }}"
-  description_template: "Wrapper for CellPose-SAM {{ tool_name }}."
+  description_template: "Wrapper for Cellpose-SAM {{ tool_name }}."

--- a/tools/cellpose_v4/.shed.yml
+++ b/tools/cellpose_v4/.shed.yml
@@ -10,4 +10,4 @@ long_description: |
     Cellpose-SAM: cell and nucleus segmentation with superhuman generalization. It can be optimized for your own data, applied in 3D, works on images with shot noise, (an)isotropic blur, undersampling, contrast inversions, regardless of channel order and object sizes.
 auto_tool_repositories:
   name_template: "{{ tool_id }}"
-  description_template: "Wrapper for CellPoseSAM {{ tool_name }}."
+  description_template: "Wrapper for CellPose-SAM {{ tool_name }}."

--- a/tools/cellpose_v4/.shed.yml
+++ b/tools/cellpose_v4/.shed.yml
@@ -2,8 +2,8 @@ name: cellposesam
 owner: bgruening
 categories:
   - Imaging
-description: CellPose SAM
-remote_repository_url: https://github.com/bgruening/galaxytools/tree/master/tools
+description: Cellpose-SAM
+remote_repository_url: https://github.com/bgruening/galaxytools/tree/master/tools/cellpose_v4
 type: unrestricted
 homepage_url: https://cellpose.org
 long_description: |
@@ -11,4 +11,3 @@ long_description: |
 auto_tool_repositories:
   name_template: "{{ tool_id }}"
   description_template: "Wrapper for CellPoseSAM {{ tool_name }}."
-

--- a/tools/cellpose_v4/cellpose.xml
+++ b/tools/cellpose_v4/cellpose.xml
@@ -2,7 +2,7 @@
     <description>with Cellpose-SAM</description>
     <macros>
         <token name="@TOOL_VERSION@">4.0.8</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">cellpose</requirement> 
@@ -97,7 +97,7 @@
         <param name="diameter" type="float" optional="true" label="Cell or nuclei diameter in pixels" help="Use to resize cells to the training diameter. Leave blank for automated estimation."/>
 	    <param name="no_resample" type="boolean" truevalue="true" falsevalue="false" checked="false" label="Disables flows/cellprob resampling to original image size before computing masks."
 		    help="Using this flag will make more masks more jagged with larger diameter settings."/>
-        <param name="no_interp" type="boolean" truevalue="true" falsevalue="false" checked="true" label="Interpolate when running dynamics."/>
+        <param name="no_interp" type="boolean" truevalue="true" falsevalue="false" checked="false" label="Do not interpolate when running dynamics."/>
         <param name="flow_threshold" type="float" min="0" value="0.4" label="Flow error threshold (all cells with errors below threshold are kept) (not used for 3D)"/>
         <param name="cellprob_threshold" type="float" value="0.0" label="Cell probability threshold (all pixels with prob above threshold kept for masks)"/>
         <param name="niter" type="integer" min="0" value="0" label="Number of iterations"
@@ -137,6 +137,9 @@
 	        <param name="save_tif" value="true"/>
             <output name="cp_tiff" file="image_cp_masks.tiff" compare="image_diff" metric="iou"/>
 	        <output name="cp_png" file="image_cp_masks.png" compare="image_diff" metric="iou"/>
+	        <section name="options">
+		        <param name="no_interp" value="true"/>
+	        </section>
 	    </test>
         <test expect_num_outputs="1">
 	        <param name="img_in" value="image3d.tiff"/>
@@ -159,6 +162,9 @@
 	        <param name="save_outlines" value="true" />
 	        <param name="use_gpu" value="true" />
 	        <param name="detailed_output" value="true" />
+	        <section name="options">
+		        <param name="no_interp" value="true"/>
+	        </section>
 	        <output name="cp_png" file="image_cp_masks.png" compare="image_diff" metric="iou"/>
             <output name="cp_flows" file="image_flows_cp_masks.tiff" compare="image_diff" />
 	        <output name="cp_flows_dp" file="image_dP_cp_masks.tiff" compare="image_diff" />
@@ -177,6 +183,7 @@
             <section name="options">
                 <param name="no_norm" value="false" />
                 <param name="no_resample" value="false" />
+		        <param name="no_interp" value="true"/>
                 <param name="diameter" value="10" />
                 <param name="flow_threshold" value="0.5" />
                 <param name="cellprob_threshold" value="0.0" />


### PR DESCRIPTION
See this discussion: https://github.com/bgruening/galaxytools/pull/1695#discussion_r3117653861

cc @sunyi000 

---

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
