### PR TITLE
Fix RAG embedding download: use snapshot_download instead of SentenceTransformer.save()

### DIFF
--- a/tools/rag/download_embeddings.py
+++ b/tools/rag/download_embeddings.py
@@ -1,9 +1,13 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = ["huggingface_hub"]
+# ///
 import argparse
 import os
 import sys
 from pathlib import Path
 
-from sentence_transformers import SentenceTransformer
+from huggingface_hub import snapshot_download
 
 
 def main():
@@ -34,8 +38,7 @@ def main():
         print(f"[PATH] Destination: {out_dir}")
 
         try:
-            model = SentenceTransformer(model_id)
-            model.save(str(out_dir))
+            snapshot_download(repo_id=model_id, local_dir=str(out_dir))
             print(f"[SUCCESS] Saved {model_id}")
         except Exception as e:
             print(f"[ERROR] Could not download {model_id}: {e}")


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] This PR updates an existing tool or tool collection

Replaces `SentenceTransformer.save()` with `huggingface_hub.snapshot_download()` in `download_embeddings.py`. ST 5.4.1's `save()` rewrites `modules.json` with class paths (`sentence_transformers.base.*`) that don't exist in ST 5.3.0 (the container version), causing `ModuleNotFoundError`. `snapshot_download` preserves HF Hub files as-is, keeping stable `sentence_transformers.models.*` paths.

Also adds PEP 723 inline metadata so `uv run` resolves deps without `--with sentence-transformers` (shrinks from 50+ packages to just `huggingface_hub`).

**Server action required:** existing model dirs on sn09 must be removed and re-downloaded with the updated script.

ref: https://github.com/usegalaxy-eu/infrastructure-playbook/pull/2020