### PR TITLE
Fix RAG Retriever crash on markdown files

### DIFF
--- a/tools/rag/rag_retriever.py
+++ b/tools/rag/rag_retriever.py
@@ -33,7 +33,7 @@ def main():
 
     docs: list[Document] = []
 
-    valid_file_types = ["pdf", "json", "txt", "csv", "md"]
+    valid_file_types = ["pdf", "json", "txt", "csv", "markdown"]
 
     for file_path, file_type in context_files:
         if file_type not in valid_file_types:

--- a/tools/rag/rag_retriever.xml
+++ b/tools/rag/rag_retriever.xml
@@ -4,7 +4,7 @@
 
   <macros>
     <token name="@TOOL_VERSION@">1.0.0</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@CONTAINER_VERSION@">0.14.18</token>
   </macros>
 


### PR DESCRIPTION
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

Fix `Unsupported file type: markdown` error. The XML declares `format="markdown"` but `valid_file_types` checked for `"md"`. Bump galaxy version suffix 0 → 1.