### PR TITLE
Update 3dtrees smart tile to v2.1.0

### DIFF
--- a/tools/3dtrees_smart_tile/smart_tile.xml
+++ b/tools/3dtrees_smart_tile/smart_tile.xml
@@ -1,7 +1,7 @@
 <tool id="3dtrees_smart_tile" name="3DTrees: SmartTile" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="24.2">
     <description>Create COPC tiles, subsample outputs, filter border overlap, and remap prediction dimensions</description>
     <macros>
-        <token name="@TOOL_VERSION@">2.0.1</token>
+        <token name="@TOOL_VERSION@">2.1.0</token>
         <token name="@VERSION_SUFFIX@">0</token>
         <xml name="produce_merged_file_param">
             <param name="produce_merged_file" type="select" label="Also write one merged output (LAZ)" help="If enabled (default), produce a single merged LAZ in addition to the per-file outputs.">
@@ -235,7 +235,7 @@
                 <param argument="--output-copc-res1" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Write resolution 1 as COPC (.copc.laz)" help="If enabled (default), the first subsampled output collection is written as COPC LAZ (`*.copc.laz`). If disabled, it is written as standard LAZ (`*.laz`). This does not affect the internal COPC-normalized source cache."/>
                 <param argument="--output-copc-res2" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Write resolution 2 as COPC (.copc.laz)" help="If enabled, the second subsampled output collection is written as COPC LAZ (`*.copc.laz`). If disabled (default), it is written as standard LAZ (`*.laz`). This matches the new SmartTile res2 COPC output option."/>
                 <param argument="--dimension-reduction" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Reduce dimensions in subsampled outputs" help="If enabled (default), subsampled outputs are written with a minimal LAS schema (smaller files). The initial source-to-COPC normalization step still preserves all input dimensions."/>
-                <param argument="--chunk-size" type="integer" min="100000" max="200000000" value="20000000" label="Chunk size (points)" help="Performance knob. Controls chunked reads used during COPC normalization and later spatial slicing steps."/>
+                <param argument="--chunk-size" type="integer" min="100000" max="200000000" value="20000000" label="Chunk size (points)" help="Performance knob. Controls chunked reads used during COPC normalization, stalled-COPC laspy fallback extraction, and later spatial slicing steps."/>
             </when>
             <when value="filter">
                 <param name="input_segmented" type="data" format="laz,las" multiple="true" label="Segmented tiles (LAZ/LAS)" help="One or more segmented tile files (e.g. `output_segmented` from RayCloudTools/SegmentAnyTree). Tip: filenames (element identifiers) should contain `cXX_rYY` so tiles and tree TXT can be matched reliably. Note: do not include mesh `.ply` files here (these inputs are LAZ/LAS only)."/>


### PR DESCRIPTION
## Summary

Updates the 3DTrees SmartTile Galaxy wrapper to use SmartTile v2.1.0 and clarifies that the chunk-size parameter also controls stalled-COPC laspy fallback extraction.

## Validation

- Parsed tools/3dtrees_smart_tile/smart_tile.xml with Python ElementTree.
- SmartTile v2.1.0 source release and GHCR image publish completed successfully upstream.
- Earlier local Galaxy tool test for 3dtrees_smart_tile passed: 4 passed, 0 failures/errors/skips.