### PR TITLE
tools: update DetailView wrapper to v1.1.1

### DIFF
--- a/tools/3dtrees_detailview/detailview.xml
+++ b/tools/3dtrees_detailview/detailview.xml
@@ -3,7 +3,7 @@
         species prediction on segmented point cloud.
     </description>
     <macros>
-        <token name="@TOOL_VERSION@">1.1.0</token>
+        <token name="@TOOL_VERSION@">1.1.1</token>
         <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>
@@ -18,6 +18,8 @@
         --n-aug '$n_aug'
         --projection-backend '$projection_backend'
         --model-path '$model_path'
+        --output-species-id-dim '$output_species_id_dim'
+        --output-species-prob-dim '$output_species_prob_dim'
         --output-type both
     ]]>
     </command>
@@ -33,6 +35,12 @@
             <option value="/app/model_europe_v1" selected="true">Europe</option>
             <option value="/app/model_global_v1">Global</option>
         </param>
+        <param argument="--output-species-id-dim" type="text" value="species_id" label="Output species ID dimension" help="Name of the LAS extra dimension used for predicted species IDs.">
+            <validator type="regex" message="Use letters, numbers, and underscores only; start with a letter">^[A-Za-z_][A-Za-z0-9_]*$</validator>
+        </param>
+        <param argument="--output-species-prob-dim" type="text" value="species_prob" label="Output species probability dimension" help="Name of the LAS extra dimension used for predicted species probabilities.">
+            <validator type="regex" message="Use letters, numbers, and underscores only; start with a letter">^[A-Za-z_][A-Za-z0-9_]*$</validator>
+        </param>
     </inputs>
     <outputs>
         <data name="predictions_csv" format="csv" label="Species Predictions" from_work_dir="predictions.csv"/>
@@ -46,6 +54,8 @@
             <param name="n_aug" value="1"/>
             <param name="projection_backend" value="torch"/>
             <param name="model_path" value="/app/model_europe_v1"/>
+            <param name="output_species_id_dim" value="species_id"/>
+            <param name="output_species_prob_dim" value="species_prob"/>
             <assert_stderr>
                 <has_n_lines n="35"/>
                 <has_text text="RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU."/>
@@ -75,6 +85,9 @@ This tool performs tree species classification on segmented 3D point clouds usin
 - **Model Region**: Select the trained model based on your data's geographic origin
   - Europe: Model trained on European tree species data
   - Global: Model trained on global tree species data
+- **Output species ID dimension**: LAS extra dimension name for predicted species IDs (default: species_id)
+- **Output species probability dimension**: LAS extra dimension name for predicted species probabilities (default: species_prob)
+  - Use different names for different segmentation branches when multiple DetailView outputs need to coexist
 
 **Outputs**
 


### PR DESCRIPTION
## Summary
- update the 3Dtrees DetailView Galaxy wrapper to use image v1.1.1
- expose configurable output species ID/probability dimension names
- keep default output dimension names as species_id and species_prob