### PR TITLE
Update SegmentAnyTree wrapper to v1.2.3

### DIFF
--- a/tools/3dtrees_segmentanytree/segmentanytree.xml
+++ b/tools/3dtrees_segmentanytree/segmentanytree.xml
@@ -61,21 +61,6 @@
         </data>
     </outputs>
     <tests>
-        <test expect_num_outputs="2">
-            <param name="input" value="prepared_files_mikro.zip"/>
-            <param name="log_file" value="true"/>
-            <param name="predinstance_name" value="predinstance_sat"/>
-            <param name="predsemantic_name" value="PredSemantic_SAT"/>
-            <output name="resource_usage">
-                <assert_contents>
-                    <has_line line="timestamp,cpu_percent,cpu_cores_used,cpu_cores_total,mem_used_mb,mem_total_mb,gpu_mem_used_mb,gpu_mem_total_mb" n="1"/>
-                </assert_contents>
-            </output>
-            <assert_stdout>
-                <has_text text="Loading checkpoint from /src/SegmentAnyTree/model_file/PointGroup-PAPER.pt"/>
-                <has_text text="Segmentation complete"/>
-            </assert_stdout>
-        </test>
         <test expect_exit_code="1" expect_failure="true">
             <param name="input" value="mikro.laz"/>
             <param name="log_file" value="false"/>

--- a/tools/3dtrees_segmentanytree/segmentanytree.xml
+++ b/tools/3dtrees_segmentanytree/segmentanytree.xml
@@ -3,7 +3,7 @@
         Forest instance segmentation.
     </description>
     <macros>
-        <token name="@TOOL_VERSION@">1.2.2</token>
+        <token name="@TOOL_VERSION@">1.2.3</token>
         <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>
@@ -43,7 +43,7 @@
     <inputs>
         <param argument="--input" type="data" format="zip,laz" label="Input Dataset" help="ZIP file containing point cloud data with required folder structure / single LAZ/LAS point cloud file."/>
         <param argument="--log_file" type="boolean" label="Resource log" help="If set to true, it returns a log file containing the CPU, RAM and GPU usage statistics"/>
-        <param argument="--predinstance_name" type="text" value="PredInstance_SAT" label="Predicted instance dimension name" help="Output dimension name for predicted tree instance IDs.">
+        <param argument="--predinstance_name" type="text" value="predinstance_sat" label="Predicted instance dimension name" help="Output dimension name for predicted tree instance IDs.">
             <validator type="regex" message="Use letters, numbers, and underscores only; start with a letter">^[A-Za-z_][A-Za-z0-9_]*$</validator>
         </param>
         <param argument="--predsemantic_name" type="text" value="PredSemantic_SAT" label="Predicted semantic dimension name" help="Output dimension name for predicted semantic labels.">
@@ -64,7 +64,7 @@
         <test expect_num_outputs="2">
             <param name="input" value="prepared_files_mikro.zip"/>
             <param name="log_file" value="true"/>
-            <param name="predinstance_name" value="PredInstance_SAT"/>
+            <param name="predinstance_name" value="predinstance_sat"/>
             <param name="predsemantic_name" value="PredSemantic_SAT"/>
             <output name="resource_usage">
                 <assert_contents>
@@ -80,7 +80,7 @@
             <param name="input" value="mikro.laz"/>
             <param name="log_file" value="false"/>
             <assert_stderr>
-                <has_text text="RuntimeError: Found no NVIDIA driver"/>
+                <has_text text="RuntimeError: Found no NVIDIA driver on your system"/>
             </assert_stderr>
             <assert_stdout>
                 <has_text text="Loading checkpoint from /src/SegmentAnyTree/model_file/PointGroup-PAPER.pt"/>

--- a/tools/3dtrees_segmentanytree/segmentanytree.xml
+++ b/tools/3dtrees_segmentanytree/segmentanytree.xml
@@ -43,7 +43,7 @@
     <inputs>
         <param argument="--input" type="data" format="zip,laz" label="Input Dataset" help="ZIP file containing point cloud data with required folder structure / single LAZ/LAS point cloud file."/>
         <param argument="--log_file" type="boolean" label="Resource log" help="If set to true, it returns a log file containing the CPU, RAM and GPU usage statistics"/>
-        <param argument="--predinstance_name" type="text" value="predinstance_sat" label="Predicted instance dimension name" help="Output dimension name for predicted tree instance IDs.">
+        <param argument="--predinstance_name" type="text" value="PredInstance_SAT" label="Predicted instance dimension name" help="Output dimension name for predicted tree instance IDs.">
             <validator type="regex" message="Use letters, numbers, and underscores only; start with a letter">^[A-Za-z_][A-Za-z0-9_]*$</validator>
         </param>
         <param argument="--predsemantic_name" type="text" value="PredSemantic_SAT" label="Predicted semantic dimension name" help="Output dimension name for predicted semantic labels.">


### PR DESCRIPTION
## Summary

Update the 3Dtrees SegmentAnyTree Galaxy wrapper to the SAT `v1.2.3` container release.

This changes the resolved Galaxy tool version to `1.2.3+galaxy0`, keeps the predicted instance output dimension aligned with the wrapper parameter default (`predinstance_sat`), and tightens the no-GPU regression assertion to the full PyTorch error text.

## Validation

- `planemo lint tools/3dtrees_segmentanytree/segmentanytree.xml`
- `planemo test --docker --docker_run_extra_arguments "--user 1010:1012" --test_index 1 --test_output tool_test_output.nogpu.html --test_output_json tool_test_output.nogpu.json tools/3dtrees_segmentanytree/segmentanytree.xml`

The targeted no-GPU test passed by asserting the expected `RuntimeError: Found no NVIDIA driver on your system` stderr. The local Planemo environment still emits an optional `hdf5`/NumPy binary compatibility warning while loading assertion modules, but lint and the targeted test both completed successfully.
