### PR TITLE
tools: revert SmartTile wrapper to v2.1.0+galaxy0

### DIFF
--- a/tools/3dtrees_smart_tile/smart_tile.xml
+++ b/tools/3dtrees_smart_tile/smart_tile.xml
@@ -1,67 +1,55 @@
 <tool id="3dtrees_smart_tile" name="3DTrees: SmartTile" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="24.2">
-    <description>Tile, merge, remap, and prod-merge point clouds</description>
+    <description>Create COPC tiles, subsample outputs, filter border overlap, and remap prediction dimensions</description>
     <macros>
-        <token name="@TOOL_VERSION@">2.2</token>
-        <token name="@VERSION_SUFFIX@">15</token>
-        <xml name="chunk_size">
-            <param argument="--chunk-size" type="integer" min="100000" max="200000000" value="20000000" label="Chunk size (points)"/>
+        <token name="@TOOL_VERSION@">2.1.0</token>
+        <token name="@VERSION_SUFFIX@">0</token>
+        <xml name="produce_merged_file_param">
+            <param name="produce_merged_file" type="select" label="Also write one merged output (LAZ)" help="If enabled (default), produce a single merged LAZ in addition to the per-file outputs.">
+                <option value="False">No</option>
+                <option value="True" selected="true">Yes</option>
+            </param>
         </xml>
-        <xml name="merged_resolution">
-            <param argument="--merged-resolutions" type="float" min="0.001" max="1.0" value="0.1" label="Prod-merged resolution (m)"/>
-        </xml>
-        <xml name="merged_format_options">
-            <option value="copc.laz" selected="true">COPC LAZ</option>
-            <option value="laz">LAZ</option>
-            <option value="ply">PLY</option>
-        </xml>
-        <xml name="prod_merged_controls">
-            <conditional name="prod_merged">
-                <param name="create" type="select" label="Create prod-merged outputs">
-                    <option value="False" selected="true">No</option>
-                    <option value="True">Yes</option>
+        <xml name="merge_enrichment_conditional">
+            <conditional name="merge_enrichment_mode">
+                <param name="transfer_original_dims_to_merged" type="select" label="Enrich merged output with original attributes" help="If producing a merged file, you can optionally add back selected original attributes before concatenation.">
+                    <option value="False">No</option>
+                    <option value="True" selected="true">Yes</option>
                 </param>
+                <when value="False"/>
                 <when value="True">
-                    <expand macro="merged_resolution"/>
-                    <param argument="--merged-output-formats" type="select" multiple="true" label="Prod-merged formats">
-                        <expand macro="merged_format_options"/>
+                    <param name="standardization_json" type="data" format="json" optional="true" label="Standardization summary (optional)" help="`collection_summary.json` from the 3Dtrees: Standardization tool. If provided, it limits which original attributes are transferred into the merged output."/>
+                    <param argument="--remap-dims" type="text" optional="true" label="Dimensions to transfer (optional allowlist)" help="Leave empty to transfer all *extra* dimensions from the source segmented tiles. If set, it becomes a strict allowlist: only the listed dimension names are transferred (standard or extra). Comma-separated, e.g. `PredInstance,Intensity`. Disclaimer: dimension names starting with a digit are sanitized for COPC, so a requested `3DT_*` dimension may appear as `TDT_*` in outputs.">
+                        <validator type="regex" message="Only letters, numbers, spaces, dots, commas, colons, underscores, and dashes are allowed">^[A-Za-z0-9 .,:_-]*$</validator>
                     </param>
                 </when>
+            </conditional>
+        </xml>
+        <xml name="merged_output_conditional">
+            <conditional name="merged_output">
+                <expand macro="produce_merged_file_param"/>
                 <when value="False"/>
+                <when value="True">
+                    <expand macro="merge_enrichment_conditional"/>
+                </when>
             </conditional>
         </xml>
     </macros>
     <requirements>
-        <container type="docker">ghcr.io/3dtrees-earth/3dtrees_smart_tile:v2.2</container>
+        <container type="docker">ghcr.io/3dtrees-earth/3dtrees_smart_tile:@TOOL_VERSION@</container>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
-        export NUMBA_CACHE_DIR="\${TMPDIR:-/tmp}/numba" &&
         mkdir -p output_dir &&
-        link_laz_input() {
-            link_src="\$1";
-            link_dir="\$2";
-            link_name="\$3";
-            case "\$link_name" in
-                *.laz|*.las|*.LAZ|*.LAS) link_out="\$link_name" ;;
-                *) link_out="\$link_name.laz" ;;
-            esac;
-            ln -s "\$link_src" "\$link_dir/\$link_out";
-        } &&
-        link_text_input() {
-            link_src="\$1";
-            link_dir="\$2";
-            link_name="\$3";
-            case "\$link_name" in
-                *.txt|*.TXT) link_out="\$link_name" ;;
-                *) link_out="\$link_name.txt" ;;
-            esac;
-            ln -s "\$link_src" "\$link_dir/\$link_out";
-        } &&
 
         #if $operation.task == 'tile':
             mkdir -p input_dir &&
             #for $f in $operation.input_files:
-                link_laz_input '$f' input_dir '${f.element_identifier}' &&
+                #set $tile_name = str($f.element_identifier)
+                #if not $tile_name.endswith('.' + str($f.ext))
+                    #set $tile_name = $tile_name + '.' + str($f.ext)
+                #end if
+                ln -s '$f' input_dir/'${tile_name}' &&
             #end for
+
             python -u /src/run.py
                 --task tile
                 --input-dir input_dir
@@ -73,418 +61,426 @@
                 #end if
                 --resolution-1 '$operation.resolution_1'
                 --resolution-2 '$operation.resolution_2'
-                --subsampling-method '$operation.subsampling_method'
-                $operation.output_copc_res1
-                $operation.output_copc_res2
+                --output-copc-res1 $operation.output_copc_res1
+                --output-copc-res2 $operation.output_copc_res2
+                --dimension-reduction $operation.dimension_reduction
                 --chunk-size '$operation.chunk_size'
-                --workers 2
-                --tile-source-workers 2
-                --tile-writer-workers 2
                 --num-spatial-chunks \${GALAXY_SLOTS:-4}
+                --workers \${GALAXY_SLOTS:-4}
                 --threads \${GALAXY_SLOTS:-4}
 
-        #elif $operation.task == 'merge':
-            mkdir -p input_segmented input_res1 &&
+        #elif $operation.task == 'filter':
+            mkdir -p input_segmented &&
             #for $f in $operation.input_segmented:
-                link_laz_input '$f' input_segmented '${f.element_identifier}' &&
+                #set $fname = str($f.element_identifier)
+                #if not $fname.endswith('.' + str($f.ext))
+                    #set $fname = $fname + '.' + str($f.ext)
+                #end if
+                ln -s '$f' input_segmented/'${fname}' &&
             #end for
-            #if $operation.tree_sidecars.mode == 'with_tree_files':
-                #for $f in $operation.tree_sidecars.input_tree_files:
-                    link_text_input '$f' input_segmented '${f.element_identifier}' &&
+            #if $operation.input_tree_files:
+                #for $f in $operation.input_tree_files:
+                    #set $fname = str($f.element_identifier)
+                    #if not $fname.endswith('.' + str($f.ext))
+                        #set $fname = $fname + '.' + str($f.ext)
+                    #end if
+                    ln -s '$f' input_segmented/'${fname}' &&
                 #end for
             #end if
-            #for $f in $operation.input_res1:
-                link_laz_input '$f' input_res1 '${f.element_identifier}' &&
-            #end for
-            #if $operation.input_original_laz:
-                mkdir -p input_original_laz &&
-                #for $f in $operation.input_original_laz:
-                    link_laz_input '$f' input_original_laz '${f.element_identifier}' &&
-                #end for
+
+            #if $operation.filter_mode.mode == 'filter_and_remap':
+                #if $operation.filter_mode.remap_target_mode.mode == 'both' or $operation.filter_mode.remap_target_mode.mode == 'originals_only':
+                    mkdir -p input_original &&
+                    #for $f in $operation.filter_mode.remap_target_mode.original_files:
+                        #set $orig_name = str($f.element_identifier)
+                        #if not $orig_name.endswith('.' + str($f.ext))
+                            #set $orig_name = $orig_name + '.' + str($f.ext)
+                        #end if
+                        ln -s '$f' 'input_original/${orig_name}' &&
+                    #end for
+                #end if
+                #if $operation.filter_mode.remap_target_mode.mode == 'both' or $operation.filter_mode.remap_target_mode.mode == 'targets_only':
+                    mkdir -p input_target &&
+                    #for $f in $operation.filter_mode.remap_target_mode.input_target_files:
+                        #set $tgt_name = str($f.element_identifier)
+                        #if not $tgt_name.endswith('.' + str($f.ext))
+                            #set $tgt_name = $tgt_name + '.' + str($f.ext)
+                        #end if
+                        ln -s '$f' 'input_target/${tgt_name}' &&
+                    #end for
+                #end if
             #end if
+
             python -u /src/run.py
-                --task merge
-                --subsampled-segmented-folder input_segmented
-                --subsampled-target-folder input_res1
-                --tile-bounds-json '$operation.tile_bounds_json'
-                --chunk-size '$operation.chunk_size'
-                --workers 2
-                --num-spatial-chunks \${GALAXY_SLOTS:-4}
-                #if $operation.input_original_laz:
-                    --original-laz-input-dir input_original_laz
-                    --original-laz-output-dir output_dir/original_with_predictions
+                --task filter
+                --segmented-folders 'input_segmented'
+                #if $operation.tile_bounds_json:
+                    --tile-bounds-json '$operation.tile_bounds_json'
                 #end if
-                --output-tiles-folder output_dir/output_tiles
-                #if $operation.tree_sidecars.mode == 'with_tree_files':
-                    --overlap-threshold 0.3
-                    --max-centroid-distance 3.0
-                    --border-zone-width 10.0
-                    --disable-matching
-                    --max-volume-for-merge 4.0
-                    --min-cluster-size 300
-                    --disable-volume-merge
-                #else
-                    #if $operation.tree_sidecars.cross_tile_matching.enabled == 'True':
-                        --overlap-threshold '$operation.tree_sidecars.cross_tile_matching.overlap_threshold'
-                        --max-centroid-distance '$operation.tree_sidecars.cross_tile_matching.max_centroid_distance'
-                        --border-zone-width '$operation.tree_sidecars.cross_tile_matching.border_zone_width'
-                    #else
-                        --overlap-threshold 0.3
-                        --max-centroid-distance 3.0
-                        --border-zone-width 10.0
-                        --disable-matching
-                    #end if
-                    #if $operation.tree_sidecars.small_cluster_reassignment.enabled == 'True':
-                        --max-volume-for-merge '$operation.tree_sidecars.small_cluster_reassignment.max_volume_for_merge'
-                        --min-cluster-size '$operation.tree_sidecars.small_cluster_reassignment.min_cluster_size'
-                    #else
-                        --max-volume-for-merge 4.0
-                        --min-cluster-size 300
-                        --disable-volume-merge
-                    #end if
-                #end if
+                --output-dir output_dir
                 --instance-dimension '$operation.instance_dimension'
-                #if $operation.prod_merged.create == 'True':
-                    --transfer-original-dims-to-merged True
-                    --output-merged-laz output_dir/merged.laz
-                    --merged-resolutions '$operation.prod_merged.merged_resolutions'
-                    --merged-output-formats '$operation.prod_merged.merged_output_formats'
-                #else
-                    --skip-merged-file
-                    --no-transfer-original-dims-to-merged
+                --filter-anchor '$operation.filter_anchor'
+                #if $operation.border_zone_mode.mode == 'manual':
+                    --border-zone-width '$operation.border_zone_mode.border_zone_width'
+                #end if
+                --chunk-size '$operation.chunk_size'
+                --workers \${GALAXY_SLOTS:-2}
+                --enable-volume-merge '$operation.small_cluster_reassignment.enabled'
+                #if $operation.small_cluster_reassignment.enabled == 'True':
+                    --min-cluster-size '$operation.small_cluster_reassignment.min_cluster_size'
+                    --max-volume-for-merge '$operation.small_cluster_reassignment.max_volume_for_merge'
+                #end if
+                #if $operation.filter_mode.mode == 'filter_and_remap':
+                    --remap-merge True
+                    #if $operation.filter_mode.remap_target_mode.mode == 'both' or $operation.filter_mode.remap_target_mode.mode == 'targets_only':
+                        --subsampled-target-folder input_target
+                    #end if
+                    --produce-merged-file $operation.filter_mode.merged_output.produce_merged_file
+                    #if $operation.filter_mode.remap_target_mode.mode == 'both' or $operation.filter_mode.remap_target_mode.mode == 'originals_only':
+                        --original-input-dir input_original
+                        #if $operation.filter_mode.merged_output.produce_merged_file == 'True':
+                            --transfer-original-dims-to-merged '$operation.filter_mode.merged_output.merge_enrichment_mode.transfer_original_dims_to_merged'
+                            #if $operation.filter_mode.merged_output.merge_enrichment_mode.transfer_original_dims_to_merged == 'True' and $operation.filter_mode.merged_output.merge_enrichment_mode.standardization_json:
+                                --standardization-json '$operation.filter_mode.merged_output.merge_enrichment_mode.standardization_json'
+                            #end if
+                        #else
+                            --transfer-original-dims-to-merged False
+                        #end if
+                    #else
+                        --transfer-original-dims-to-merged False
+                    #end if
+                    #if $operation.filter_mode.merged_output.produce_merged_file == 'True' and $operation.filter_mode.merged_output.merge_enrichment_mode.transfer_original_dims_to_merged == 'True' and $operation.filter_mode.merged_output.merge_enrichment_mode.remap_dims:
+                        --remap-dims '$operation.filter_mode.merged_output.merge_enrichment_mode.remap_dims'
+                    #end if
                 #end if
 
         #elif $operation.task == 'remap':
-            mkdir -p input_original_laz output_dir/original_with_predictions &&
-            #for $f in $operation.original_files:
-                link_laz_input '$f' input_original_laz '${f.element_identifier}' &&
-            #end for
-            #if $operation.remap_source.source == 'merged_file':
-                #if $operation.remap_source.merged_file_is_copc:
-                    ln -s '$operation.remap_source.merged_file' merged_input.copc.laz &&
+            mkdir -p input_original &&
+            #set $seg_folders = ''
+            #set $coll_idx = 0
+            #for $item in $operation.segmented_collections:
+                #set $coll_idx = $coll_idx + 1
+                #set $folder = 'input_segmented_' + str($coll_idx)
+                #if $seg_folders
+                    #set $seg_folders = $seg_folders + ',' + $folder
                 #else
-                    ln -s '$operation.remap_source.merged_file' merged_input.laz &&
+                    #set $seg_folders = $folder
                 #end if
-            #else
-                mkdir -p input_prediction_collections &&
-                segmented_folders="" &&
-                collection_idx=0 &&
-                #for $seg in $operation.remap_source.segmented_collections:
-                    collection_dir="input_prediction_collections/collection_\${collection_idx}" &&
-                    mkdir -p "\$collection_dir" &&
-                    #for $f in $seg.collection:
-                        link_laz_input '$f' "\$collection_dir" '${f.element_identifier}' &&
-                    #end for
-                    if [ -z "\$segmented_folders" ]; then
-                        segmented_folders="\$collection_dir";
-                    else
-                        segmented_folders="\$segmented_folders,\$collection_dir";
-                    fi &&
-                    collection_idx=\$((collection_idx + 1)) &&
+                mkdir -p $folder &&
+                #for $f in $item.collection:
+                    #set $ext = str($f.ext)
+                    #set $stem = str($f.element_identifier)
+                    #if $stem.endswith('.' + $ext)
+                        #set $stem = $stem[:-(len($ext) + 1)]
+                    #end if
+                    ln -s '$f' ${folder}/'${stem}_${coll_idx}.${ext}' &&
+                #end for
+            #end for
+            #for $f in $operation.original_files:
+                #set $orig_name = str($f.element_identifier)
+                #if not $orig_name.endswith('.' + str($f.ext))
+                    #set $orig_name = $orig_name + '.' + str($f.ext)
+                #end if
+                ln -s '$f' 'input_original/${orig_name}' &&
+            #end for
+            #if $operation.input_target_files:
+                mkdir -p input_target &&
+                #for $f in $operation.input_target_files:
+                    #set $tgt_name = str($f.element_identifier)
+                    #if not $tgt_name.endswith('.' + str($f.ext))
+                        #set $tgt_name = $tgt_name + '.' + str($f.ext)
+                    #end if
+                    ln -s '$f' 'input_target/${tgt_name}' &&
                 #end for
             #end if
+
             python -u /src/run.py
                 --task remap
-                #if $operation.remap_source.source == 'merged_file':
-                    #if $operation.remap_source.merged_file_is_copc:
-                        --merged-laz merged_input.copc.laz
-                    #else
-                        --merged-laz merged_input.laz
-                    #end if
-                #else
-                    --segmented-folders "\$segmented_folders"
-                    #if $operation.remap_source.remap_dims:
-                        --remap-dims '$operation.remap_source.remap_dims'
-                    #end if
-                #end if
-                --original-laz-input-dir input_original_laz
-                --original-laz-output-dir output_dir/original_with_predictions
-                --workers 2
-                --num-spatial-chunks \${GALAXY_SLOTS:-4}
-                #if $operation.prod_merged.create == 'True':
-                    --transfer-original-dims-to-merged True
-                    --merged-resolutions '$operation.prod_merged.merged_resolutions'
-                    --merged-output-formats '$operation.prod_merged.merged_output_formats'
-                #else
-                    --no-transfer-original-dims-to-merged
+                --segmented-folders '$seg_folders'
+                --original-input-dir input_original
+                --output-dir output_dir
+                #if $operation.input_target_files:
+                    --subsampled-target-folder input_target
                 #end if
                 --chunk-size '$operation.chunk_size'
-
-        #elif $operation.task == 'create_merged_file':
-            mkdir -p original_with_predictions &&
-            #for $f in $operation.original_with_predictions:
-                link_laz_input '$f' original_with_predictions '${f.element_identifier}' &&
-            #end for
-            python -u /src/run.py
-                --task create_merged_file
-                --original-with-predictions-dir original_with_predictions
-                --output-dir output_dir
-                --merged-resolutions '$operation.merged_resolutions'
-                --merged-output-formats '$operation.merged_output_formats'
-                --workers 2
-                --num-spatial-chunks \${GALAXY_SLOTS:-4}
+                --workers \${GALAXY_SLOTS:-2}
+                --produce-merged-file $operation.merged_output.produce_merged_file
+                #if $operation.merged_output.produce_merged_file == 'True':
+                    --transfer-original-dims-to-merged '$operation.merged_output.merge_enrichment_mode.transfer_original_dims_to_merged'
+                    #if $operation.merged_output.merge_enrichment_mode.transfer_original_dims_to_merged == 'True' and $operation.merged_output.merge_enrichment_mode.standardization_json:
+                        --standardization-json '$operation.merged_output.merge_enrichment_mode.standardization_json'
+                    #end if
+                #else
+                    --transfer-original-dims-to-merged False
+                #end if
+                #if $operation.merged_output.produce_merged_file == 'True' and $operation.merged_output.merge_enrichment_mode.transfer_original_dims_to_merged == 'True' and $operation.merged_output.merge_enrichment_mode.remap_dims:
+                    --remap-dims '$operation.merged_output.merge_enrichment_mode.remap_dims'
+                #end if
         #end if
     ]]></command>
     <inputs>
         <conditional name="operation">
-            <param name="task" type="select" label="Task">
-                <option value="tile">Tile and subsample</option>
-                <option value="merge">Filter/Merge segmented tiles</option>
-                <option value="remap">Remap predictions to originals</option>
-                <option value="create_merged_file">Create prod-merged file</option>
+            <param name="task" type="select" label="Operation">
+                <option value="tile">Tile (COPC normalize + tile + subsample)</option>
+                <option value="filter">Filter (remove overlap-only instances)</option>
+                <option value="remap">Remap (transfer dimensions back to originals)</option>
             </param>
             <when value="tile">
-                <param name="input_files" type="data" format="laz,las" multiple="true" label="Input LAZ/LAS files"/>
-                <param argument="--tile-length" type="integer" min="1" max="10000" value="300" label="Tile length (m)"/>
-                <param argument="--tile-buffer" type="integer" min="0" max="10000" value="20" label="Tile buffer (m)"/>
-                <param argument="--tiling-threshold" type="float" min="0.1" max="50000" value="10000" optional="true" label="Tiling threshold (MB)"/>
-                <param argument="--resolution-1" type="float" min="0.001" max="1.0" value="0.01" label="Resolution 1 (m)"/>
-                <param argument="--resolution-2" type="float" min="0.001" max="1.0" value="0.1" label="Resolution 2 (m)"/>
-                <param argument="--subsampling-method" type="select" label="Subsampling method">
-                    <option value="center-of-mass" selected="true">Center of mass</option>
-                    <option value="nearest-to-centroid">Nearest to centroid</option>
-                </param>
-                <param argument="--output-copc-res1" type="boolean" truevalue="--output-copc-res1 True" falsevalue="--output-copc-res1 False" checked="true" label="Write resolution 1 as COPC LAZ"/>
-                <param argument="--output-copc-res2" type="boolean" truevalue="--output-copc-res2 True" falsevalue="--output-copc-res2 False" checked="false" label="Write resolution 2 as COPC LAZ"/>
-                <param name="return_original_copc" type="boolean" truevalue="true" falsevalue="false" checked="false" label="Return COPC-normalized originals"/>
-                <expand macro="chunk_size"/>
+                <param name="input_files" type="data" format="laz,las" multiple="true" label="Input point clouds (LAZ/LAS)" help="One or more point-cloud files to COPC-normalize, tile, and subsample."/>
+                <param argument="--tile-length" type="integer" min="1" max="10000" value="300" label="Tile size (m)" help="Tile edge length in meters."/>
+                <param argument="--tile-buffer" type="integer" min="1" max="10000" value="20" label="Overlap buffer (m)" help="Extra overlap on each tile edge, in meters."/>
+                <param argument="--tiling-threshold" type="float" min="0.1" max="50000" value="10000" optional="true" label="Skip tiling below (MB)" help="If a single input file is below this size, SmartTile may skip physical tile generation after COPC normalization and subsample directly from the normalized source."/>
+                <param argument="--resolution-1" type="float" min="0.001" max="1.0" value="0.01" label="Subsample resolution 1 (m)" help="First subsampling resolution, in meters."/>
+                <param argument="--resolution-2" type="float" min="0.001" max="1.0" value="0.1" label="Subsample resolution 2 (m)" help="Second subsampling resolution, in meters."/>
+                <param argument="--output-copc-res1" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Write resolution 1 as COPC (.copc.laz)" help="If enabled (default), the first subsampled output collection is written as COPC LAZ (`*.copc.laz`). If disabled, it is written as standard LAZ (`*.laz`). This does not affect the internal COPC-normalized source cache."/>
+                <param argument="--output-copc-res2" type="boolean" truevalue="True" falsevalue="False" checked="false" label="Write resolution 2 as COPC (.copc.laz)" help="If enabled, the second subsampled output collection is written as COPC LAZ (`*.copc.laz`). If disabled (default), it is written as standard LAZ (`*.laz`). This matches the new SmartTile res2 COPC output option."/>
+                <param argument="--dimension-reduction" type="boolean" truevalue="True" falsevalue="False" checked="true" label="Reduce dimensions in subsampled outputs" help="If enabled (default), subsampled outputs are written with a minimal LAS schema (smaller files). The initial source-to-COPC normalization step still preserves all input dimensions."/>
+                <param argument="--chunk-size" type="integer" min="100000" max="200000000" value="20000000" label="Chunk size (points)" help="Performance knob. Controls chunked reads used during COPC normalization, stalled-COPC laspy fallback extraction, and later spatial slicing steps."/>
             </when>
-            <when value="merge">
-                <param name="input_segmented" type="data" format="laz" multiple="true" label="Primary segmented files"/>
-                <param name="input_res1" type="data" format="laz" multiple="true" label="Target-resolution subsampled files"/>
-                <param name="input_original_laz" type="data" format="laz,las" multiple="true" optional="true" label="Original LAZ/LAS files"/>
-                <param name="tile_bounds_json" type="data" format="json" label="Tile bounds JSON"/>
-                <expand macro="chunk_size"/>
-                <param argument="--instance-dimension" type="text" value="PredInstance" label="Instance dimension"/>
-                <conditional name="tree_sidecars">
-                    <param name="mode" type="select" label="Tree sidecar files">
-                        <option value="none" selected="true">No tree sidecars</option>
-                        <option value="with_tree_files">Use primary tree sidecar files</option>
+            <when value="filter">
+                <param name="input_segmented" type="data" format="laz,las" multiple="true" label="Segmented tiles (LAZ/LAS)" help="One or more segmented tile files (e.g. `output_segmented` from RayCloudTools/SegmentAnyTree). Tip: filenames (element identifiers) should contain `cXX_rYY` so tiles and tree TXT can be matched reliably. Note: do not include mesh `.ply` files here (these inputs are LAZ/LAS only)."/>
+                <param name="input_tree_files" type="data" format="txt" multiple="true" optional="true" label="Tree files (TXT, optional)" help="Per-tile tree TXT sidecars (e.g. `output_trees`). If provided, SmartTile will carry them along and (if possible) rename them consistently with the tile IDs."/>
+                <param name="tile_bounds_json" type="data" format="json" optional="true" label="Tile layout JSON (tile_bounds_tindex.json)" help="Tile layout metadata for neighbor lookup and border ownership. Optional: when omitted, neighbors are detected from cXX_rYY filename coordinates."/>
+                <param argument="--instance-dimension" type="text" value="PredInstance" label="Instance ID dimension" help="Name of the instance-ID dimension in the segmented input files (e.g. `PredInstance`, `PredInstance_RCT`).">
+                    <validator type="regex" message="Only letters, numbers, spaces, dots, commas, colons, underscores, and dashes are allowed (empty allowed)">^[A-Za-z0-9 .,:_-]*$</validator>
+                </param>
+                <param argument="--filter-anchor" type="select" label="Border assignment anchor" help="Representative point used to decide whether an instance belongs to the border zone.">
+                    <option value="centroid" selected="true">Centroid</option>
+                    <option value="highest_point">Highest Point</option>
+                    <option value="lowest_point">Lowest Point</option>
+                </param>
+                <conditional name="border_zone_mode">
+                    <param name="mode" type="select" label="Border zone width" help="By default the border/overlap width is derived from the tile layout JSON. Only override this if your tile layout and your data overlap do not match.">
+                        <option value="auto" selected="true">Derive from tile layout JSON (recommended)</option>
+                        <option value="manual">Override manually</option>
                     </param>
-                    <when value="none">
-                        <conditional name="cross_tile_matching">
-                            <param name="enabled" type="select" label="Cross-tile merging">
-                                <option value="True" selected="true">Enabled</option>
-                                <option value="False">Disabled</option>
-                            </param>
-                            <when value="True">
-                                <param argument="--overlap-threshold" type="float" min="0" max="1" value="0.3" label="Overlap threshold"/>
-                                <param argument="--max-centroid-distance" type="float" min="0" max="100" value="3.0" label="Max centroid distance (m)"/>
-                                <param argument="--border-zone-width" type="float" min="0" max="100" value="10.0" label="Border zone width (m)" help="Candidate band around tile-core edges; separate from the tile buffer in the tile bounds JSON."/>
-                            </when>
-                            <when value="False"/>
-                        </conditional>
-                        <conditional name="small_cluster_reassignment">
-                            <param name="enabled" type="select" label="Small cluster reassignment">
-                                <option value="True" selected="true">Enabled</option>
-                                <option value="False">Disabled</option>
-                            </param>
-                            <when value="True">
-                                <param argument="--max-volume-for-merge" type="float" min="0" max="100" value="4.0" label="Max volume for reassignment (m3)"/>
-                                <param argument="--min-cluster-size" type="integer" min="1" max="10000" value="300" label="Minimum cluster size"/>
-                            </when>
-                            <when value="False"/>
-                        </conditional>
-                    </when>
-                    <when value="with_tree_files">
-                        <param name="input_tree_files" type="data" format="txt" multiple="true" label="Tree files from 3dtrees_raycloudtools" help="Use the *_trees.txt and *_trees_info.txt files emitted by 3dtrees_raycloudtools for the primary segmented files."/>
+                    <when value="auto"/>
+                    <when value="manual">
+                        <param argument="--border-zone-width" type="float" min="0" max="1000" label="Border zone width override (m)" help="Manual override for the border/overlap zone width, in meters."/>
                     </when>
                 </conditional>
-                <expand macro="prod_merged_controls"/>
+                <conditional name="small_cluster_reassignment">
+                    <param name="enabled" type="select" label="Small cluster reassignment" help="If enabled (default), very small kept instances can be reassigned/merged based on size and volume thresholds below.">
+                        <option value="False">Disabled</option>
+                        <option value="True" selected="true">Enabled</option>
+                    </param>
+                    <when value="False"/>
+                    <when value="True">
+                        <param argument="--min-cluster-size" type="integer" min="1" max="10000" value="300" label="Min points per instance" help="Instances smaller than this (in points) are eligible for reassignment."/>
+                        <param argument="--max-volume-for-merge" type="float" min="0" max="100" value="5.0" label="Max instance volume (m³)" help="Maximum convex hull volume (m³) for reassignment."/>
+                    </when>
+                </conditional>
+                <conditional name="filter_mode">
+                    <param name="mode" type="select" label="After filtering">
+                        <option value="filter_only" selected="true">Only write filtered tiles</option>
+                        <option value="filter_and_remap">Also remap filtered dimensions to another collection</option>
+                    </param>
+                    <when value="filter_only"/>
+                    <when value="filter_and_remap">
+                        <conditional name="remap_target_mode">
+                            <param name="mode" type="select" label="Remap target files" help="Choose which collections receive remapped dimensions after filtering.">
+                                <option value="both" selected="true">Originals and subsampled targets</option>
+                                <option value="originals_only">Originals only</option>
+                                <option value="targets_only">Subsampled targets only</option>
+                            </param>
+                            <when value="both">
+                                <param name="original_files" type="data" format="laz,las" multiple="true" label="Original files (LAZ/LAS)" help="Original point clouds to receive the remapped (filtered) dimensions."/>
+                                <param name="input_target_files" type="data" format="laz,las" multiple="true" label="Subsampled target files (LAZ/LAS)" help="Subsampled target point clouds to receive remapped dimensions (in addition to originals)."/>
+                            </when>
+                            <when value="originals_only">
+                                <param name="original_files" type="data" format="laz,las" multiple="true" label="Original files (LAZ/LAS)" help="Original point clouds to receive the remapped (filtered) dimensions."/>
+                            </when>
+                            <when value="targets_only">
+                                <param name="input_target_files" type="data" format="laz,las" multiple="true" label="Subsampled target files (LAZ/LAS)" help="Subsampled target point clouds to receive remapped dimensions."/>
+                            </when>
+                        </conditional>
+                        <expand macro="merged_output_conditional"/>
+                    </when>
+                </conditional>
+                <param argument="--chunk-size" type="integer" min="100000" max="200000000" value="20000000" label="Chunk size (points)" help="Performance knob. Controls chunked reads used for filtering and (optional) COPC preparation for remap."/>
             </when>
             <when value="remap">
-                <conditional name="remap_source">
-                    <param name="source" type="select" label="Prediction source">
-                        <option value="prediction_collections" selected="true">Subsampled prediction files</option>
-                        <option value="merged_file">One merged file</option>
-                    </param>
-                    <when value="merged_file">
-                        <param name="merged_file" type="data" format="laz" label="Merged LAZ/COPC LAZ file"/>
-                        <param name="merged_file_is_copc" type="boolean" truevalue="true" falsevalue="false" checked="false" label="Merged file is COPC LAZ"/>
-                    </when>
-                    <when value="prediction_collections">
-                        <repeat name="segmented_collections" title="Segmented collection" min="1">
-                            <param name="collection" type="data_collection" collection_type="list" format="laz,las" label="Segmented files collection"/>
-                        </repeat>
-                        <param argument="--remap-dims" type="text" optional="true" label="Dimension allowlist" help="Comma-separated extra dimensions to transfer; empty transfers all extra dimensions."/>
-                    </when>
-                </conditional>
-                <param name="original_files" type="data" format="laz,las" multiple="true" label="Original LAZ/LAS files"/>
-                <expand macro="prod_merged_controls"/>
-                <expand macro="chunk_size"/>
-            </when>
-            <when value="create_merged_file">
-                <param name="original_with_predictions" type="data" format="laz,las" multiple="true" label="Original-with-predictions files"/>
-                <expand macro="merged_resolution"/>
-                <param argument="--merged-output-formats" type="select" multiple="true" label="Output formats">
-                    <expand macro="merged_format_options"/>
-                </param>
+                <repeat name="segmented_collections" title="Segmented tiles (one source)" min="1" help="Add one entry per segmentation source (for example one for 3Dtrees: Raycloudtools and one for 3Dtrees: SegmentAnyTree). Each entry is staged in its own folder so overlapping tile IDs from different sources do not collide.">
+                    <param name="collection" type="data" format="laz,las" multiple="true" label="Segmented tiles (LAZ/LAS)" help="Segmented tiles from one source."/>
+                </repeat>
+                <param name="original_files" type="data" format="laz,las" multiple="true" label="Original files (LAZ/LAS)" help="Original point clouds to receive the remapped dimensions."/>
+                <param name="input_target_files" type="data" format="laz,las" multiple="true" optional="true" label="Subsampled target files (optional)" help="Optional target point clouds to receive remapped dimensions before the originals."/>
+                <expand macro="merged_output_conditional"/>
+                <param argument="--chunk-size" type="integer" min="100000" max="200000000" value="20000000" label="Chunk size (points)" help="Performance knob. Controls chunked reads used for remap-style spatial slicing and source normalization."/>
             </when>
         </conditional>
     </inputs>
     <outputs>
-        <collection name="output_subsampled_res1" type="list" label="${tool.name}: Subsampled ${operation.resolution_1}m">
+        <collection name="output_subsampled_res1" type="list" label="${tool.name}: Subsampled tiles (resolution 1)">
             <filter>operation['task'] == "tile"</filter>
-            <discover_datasets pattern="(?P&lt;designation&gt;.+\.la[sz])$" directory="output_dir/subsampled_res1" format="laz" recurse="false"/>
+            <discover_datasets pattern="(?P&lt;designation&gt;.*)\.laz" directory="output_dir/subsampled_res1" format="laz" recurse="false"/>
         </collection>
-        <collection name="output_subsampled_res2" type="list" label="${tool.name}: Subsampled ${operation.resolution_2}m">
+        <collection name="output_subsampled_res2" type="list" label="${tool.name}: Subsampled tiles (resolution 2)">
             <filter>operation['task'] == "tile"</filter>
-            <discover_datasets pattern="(?P&lt;designation&gt;.+\.la[sz])$" directory="output_dir/subsampled_res2" format="laz" recurse="false"/>
+            <discover_datasets pattern="(?P&lt;designation&gt;.*)\.laz" directory="output_dir/subsampled_res2" format="laz" recurse="false"/>
         </collection>
-        <data name="output_png" format="png" label="${tool.name}: Tiling preview" from_work_dir="output_dir/overview_copc_tiles.png">
+        <collection name="output_original_copc" type="list" label="${tool.name}: COPC-normalized originals">
+            <filter>operation['task'] == "tile"</filter>
+            <discover_datasets pattern="(?P&lt;designation&gt;.*)\.laz" directory="output_dir/original_copc" format="laz" recurse="false"/>
+        </collection>
+        <data name="output_tiling_preview" format="png" label="${tool.name}: Tiling preview (PNG)" from_work_dir="output_dir/overview_copc_tiles.png">
             <filter>operation['task'] == "tile"</filter>
         </data>
-        <data name="tile_bounds_json" format="json" label="${tool.name}: Tile bounds JSON" from_work_dir="output_dir/tile_bounds_tindex.json">
+        <data name="output_tile_bounds_json" format="json" label="${tool.name}: Tile layout (tile_bounds_tindex.json)" from_work_dir="output_dir/tile_bounds_tindex.json">
             <filter>operation['task'] == "tile"</filter>
         </data>
-        <collection name="Original_COPC" type="list" label="${tool.name}: COPC-normalized originals">
-            <filter>operation['task'] == "tile" and operation['return_original_copc'] in [True, "true", "True"]</filter>
-            <discover_datasets pattern="(?P&lt;designation&gt;.+\.la[sz])$" directory="output_dir/original_copc" format="laz" recurse="false"/>
+
+        <collection name="output_filtered_tiles" type="list" label="${tool.name}: Filtered tiles (LAZ)">
+            <filter>operation['task'] == "filter"</filter>
+            <discover_datasets pattern="__name_and_ext__" directory="output_dir/filtered_tiles" format="laz" recurse="false"/>
         </collection>
-        <collection name="output_merge_tiles" type="list" label="${tool.name}: Merged target-resolution tiles">
-            <filter>operation['task'] == "merge"</filter>
-            <discover_datasets pattern="(?P&lt;designation&gt;.+\.la[sz])$" directory="output_dir/output_tiles" format="laz" recurse="false"/>
+        <collection name="output_filtered_trees" type="list" label="${tool.name}: Filtered tree files (TXT)">
+            <filter>operation['task'] == "filter"</filter>
+            <discover_datasets pattern="__name_and_ext__" directory="output_dir/filtered_trees" format="txt" recurse="false"/>
         </collection>
-        <collection name="output_tree_files" type="list" label="${tool.name}: Filtered 3dtrees_raycloudtools tree files">
-            <filter>operation['task'] == "merge" and operation['tree_sidecars']['mode'] == "with_tree_files"</filter>
-            <discover_datasets pattern="(?P&lt;designation&gt;.+\.txt)$" directory="output_dir/segmented_filtered" format="txt" recurse="false"/>
-        </collection>
-        <data name="output_merged_laz" format="laz" label="${tool.name}: Processed merged LAZ" from_work_dir="output_dir/merged.laz">
-            <filter>operation['task'] == "merge" and operation['prod_merged']['create'] == "True"</filter>
-        </data>
-        <collection name="output_originals_with_dims" type="list" label="${tool.name}: Original files with predictions">
-            <filter>operation['task'] == "remap"</filter>
+
+        <collection name="output_originals_with_dims" type="list" label="${tool.name}: Originals with transferred dimensions">
+            <filter>operation['task'] == "remap" or (operation['task'] == "filter" and operation['filter_mode']['mode'] == "filter_and_remap")</filter>
             <discover_datasets pattern="__name_and_ext__" directory="output_dir/original_with_predictions" format="laz" recurse="false"/>
         </collection>
-        <collection name="prod_merged_outputs" type="list" label="${tool.name}: Prod-merged LAZ/COPC products">
-            <filter>(operation['task'] == "create_merged_file" and ("laz" in operation['merged_output_formats'] or "copc.laz" in operation['merged_output_formats'])) or (operation['task'] == "remap" and operation['prod_merged']['create'] == "True" and ("laz" in operation['prod_merged']['merged_output_formats'] or "copc.laz" in operation['prod_merged']['merged_output_formats'])) or (operation['task'] == "merge" and operation['prod_merged']['create'] == "True" and operation['input_original_laz'] and ("laz" in operation['prod_merged']['merged_output_formats'] or "copc.laz" in operation['prod_merged']['merged_output_formats']))</filter>
-            <discover_datasets pattern="(?P&lt;designation&gt;prod_merged_.*\.laz)$" directory="output_dir" format="laz" recurse="false"/>
+        <collection name="output_subsampled_with_dims" type="list" label="${tool.name}: Targets with transferred dimensions">
+            <filter>(operation['task'] == "remap" and operation['input_target_files']) or (operation['task'] == "filter" and operation['filter_mode']['mode'] == "filter_and_remap" and (str(operation['filter_mode']['remap_target_mode']['mode']) == "both" or str(operation['filter_mode']['remap_target_mode']['mode']) == "targets_only"))</filter>
+            <discover_datasets pattern="__name_and_ext__" directory="output_dir/subsampled_with_predictions" format="laz" recurse="false"/>
         </collection>
-        <collection name="prod_merged_ply_outputs" type="list" label="${tool.name}: Prod-merged PLY products">
-            <filter>(operation['task'] == "create_merged_file" and "ply" in operation['merged_output_formats']) or (operation['task'] == "remap" and operation['prod_merged']['create'] == "True" and "ply" in operation['prod_merged']['merged_output_formats']) or (operation['task'] == "merge" and operation['prod_merged']['create'] == "True" and operation['input_original_laz'] and "ply" in operation['prod_merged']['merged_output_formats'])</filter>
-            <discover_datasets pattern="(?P&lt;designation&gt;prod_merged_.*\.ply)$" directory="output_dir" format="plybinary" recurse="false"/>
-        </collection>
+        <data name="output_remap_merged_laz" format="laz" label="${tool.name}: Merged output (LAZ)" from_work_dir="output_dir/merged_with_all_dims.laz">
+            <filter>(operation['task'] == "remap" and str(operation['merged_output']['produce_merged_file']) == "True" and str(operation['merged_output']['merge_enrichment_mode']['transfer_original_dims_to_merged']) == "False") or (operation['task'] == "filter" and operation['filter_mode']['mode'] == "filter_and_remap" and str(operation['filter_mode']['merged_output']['produce_merged_file']) == "True" and str(operation['filter_mode']['merged_output']['merge_enrichment_mode']['transfer_original_dims_to_merged']) == "False")</filter>
+        </data>
+        <data name="output_merged_with_originals" format="laz" label="${tool.name}: Merged output with original attributes (LAZ)" from_work_dir="output_dir/merged_with_originals.laz">
+            <filter>(operation['task'] == "remap" and str(operation['merged_output']['produce_merged_file']) == "True" and str(operation['merged_output']['merge_enrichment_mode']['transfer_original_dims_to_merged']) == "True") or (operation['task'] == "filter" and operation['filter_mode']['mode'] == "filter_and_remap" and str(operation['filter_mode']['merged_output']['produce_merged_file']) == "True" and str(operation['filter_mode']['merged_output']['merge_enrichment_mode']['transfer_original_dims_to_merged']) == "True")</filter>
+        </data>
     </outputs>
     <tests>
-        <test expect_num_outputs="4">
+        <test expect_num_outputs="5">
             <conditional name="operation">
                 <param name="task" value="tile"/>
-                <param name="input_files" value="mikro"/>
+                <param name="input_files" value="mikro" ftype="laz"/>
                 <param name="tiling_threshold" value="10000"/>
                 <param name="resolution_1" value="0.01"/>
                 <param name="resolution_2" value="0.1"/>
             </conditional>
+            <output_collection name="output_original_copc" type="list" count="1"/>
             <output_collection name="output_subsampled_res1" type="list" count="1"/>
             <output_collection name="output_subsampled_res2" type="list" count="1"/>
-            <output name="output_png">
+            <output name="output_tiling_preview">
                 <assert_contents>
-                    <has_image_center_of_mass center_of_mass="1813, 1768" eps="100"/>
+                    <has_image_center_of_mass center_of_mass="1974, 1785" eps="100"/>
                 </assert_contents>
             </output>
-            <output name="tile_bounds_json">
+            <output name="output_tile_bounds_json">
                 <assert_contents>
                     <has_json_property_with_value property="tile_length" value="300"/>
                     <has_json_property_with_value property="tile_buffer" value="20"/>
                 </assert_contents>
             </output>
         </test>
-        <test expect_num_outputs="5">
+        <test expect_num_outputs="2">
             <conditional name="operation">
-                <param name="task" value="tile"/>
-                <param name="input_files" value="mikro"/>
-                <param name="tiling_threshold" value="10000"/>
-                <param name="resolution_1" value="0.01"/>
-                <param name="resolution_2" value="0.1"/>
-                <param name="return_original_copc" value="true"/>
+                <param name="task" value="filter"/>
+                <param name="instance_dimension" value="PredInstance"/>
+                <param name="input_segmented" value="mikro_segmented_rct" ftype="laz"/>
+                <param name="input_tree_files" value="c00_r00_trees.txt"/>
+                <param name="tile_bounds_json" value="tile_bounds_tindex.json"/>
+                <conditional name="filter_mode">
+                    <param name="mode" value="filter_only"/>
+                </conditional>
             </conditional>
-            <output_collection name="output_subsampled_res1" type="list" count="1"/>
-            <output_collection name="output_subsampled_res2" type="list" count="1"/>
-            <output_collection name="Original_COPC" type="list" count="1"/>
+            <output_collection name="output_filtered_tiles" type="list" count="1"/>
+            <output_collection name="output_filtered_trees" type="list" count="1"/>
         </test>
         <test expect_num_outputs="3">
             <conditional name="operation">
-                <param name="task" value="merge"/>
-                <param name="input_segmented" value="mikro_segmented"/>
-                <param name="input_res1" value="mikro_res1"/>
-                <param name="input_original_laz" value="mikro"/>
+                <param name="task" value="filter"/>
+                <param name="instance_dimension" value="PredInstance"/>
+                <param name="input_segmented" value="mikro_segmented_rct" ftype="laz"/>
+                <param name="input_tree_files" value="c00_r00_trees.txt"/>
                 <param name="tile_bounds_json" value="tile_bounds_tindex.json"/>
-                <conditional name="prod_merged">
-                    <param name="create" value="True"/>
-                    <param name="merged_resolutions" value="0.1"/>
-                    <param name="merged_output_formats" value="copc.laz"/>
+                <conditional name="filter_mode">
+                    <param name="mode" value="filter_and_remap"/>
+                    <conditional name="remap_target_mode">
+                        <param name="mode" value="originals_only"/>
+                        <param name="original_files" value="mikro" ftype="laz"/>
+                    </conditional>
+                    <conditional name="merged_output">
+                        <param name="produce_merged_file" value="False"/>
+                    </conditional>
                 </conditional>
             </conditional>
-            <output_collection name="output_merge_tiles" type="list" count="1"/>
-            <output name="output_merged_laz">
-                <assert_contents>
-                    <has_size value="43000" delta="6000"/>
-                </assert_contents>
-            </output>
-            <output_collection name="prod_merged_outputs" type="list" count="1"/>
-        </test>
-        <test expect_num_outputs="1">
-            <conditional name="operation">
-                <param name="task" value="merge"/>
-                <param name="input_segmented" value="mikro_segmented"/>
-                <param name="input_res1" value="mikro_res1"/>
-                <param name="input_original_laz" value="mikro"/>
-                <param name="tile_bounds_json" value="tile_bounds_tindex.json"/>
-                <conditional name="prod_merged">
-                    <param name="create" value="False"/>
-                </conditional>
-            </conditional>
-            <output_collection name="output_merge_tiles" type="list" count="1"/>
-        </test>
-        <test expect_num_outputs="1">
-            <conditional name="operation">
-                <param name="task" value="create_merged_file"/>
-                <param name="original_with_predictions" value="mikro_segmented"/>
-                <param name="merged_resolutions" value="0.1"/>
-                <param name="merged_output_formats" value="copc.laz"/>
-            </conditional>
-            <output_collection name="prod_merged_outputs" type="list" count="1"/>
-        </test>
-        <test expect_num_outputs="1">
-            <conditional name="operation">
-                <param name="task" value="create_merged_file"/>
-                <param name="original_with_predictions" value="mikro_segmented"/>
-                <param name="merged_resolutions" value="0.1"/>
-                <param name="merged_output_formats" value="ply"/>
-            </conditional>
-            <output_collection name="prod_merged_ply_outputs" type="list" count="1"/>
+            <output_collection name="output_filtered_tiles" type="list" count="1"/>
+            <output_collection name="output_filtered_trees" type="list" count="1"/>
+            <output_collection name="output_originals_with_dims" type="list" count="1"/>
         </test>
         <test expect_num_outputs="2">
             <conditional name="operation">
                 <param name="task" value="remap"/>
-                <conditional name="remap_source">
-                    <param name="source" value="merged_file"/>
-                    <param name="merged_file" value="mikro_segmented"/>
-                </conditional>
-                <param name="original_files" value="mikro"/>
-                <conditional name="prod_merged">
-                    <param name="create" value="True"/>
-                    <param name="merged_resolutions" value="0.1"/>
-                    <param name="merged_output_formats" value="copc.laz"/>
+                <repeat name="segmented_collections">
+                    <param name="collection" value="mikro_segmented" ftype="laz"/>
+                </repeat>
+                <repeat name="segmented_collections">
+                    <param name="collection" value="mikro_segmented_rct" ftype="laz"/>
+                </repeat>
+                <param name="original_files" value="mikro" ftype="laz"/>
+                <conditional name="merged_output">
+                    <param name="produce_merged_file" value="True"/>
+                    <conditional name="merge_enrichment_mode">
+                        <param name="transfer_original_dims_to_merged" value="True"/>
+                    </conditional>
                 </conditional>
             </conditional>
             <output_collection name="output_originals_with_dims" type="list" count="1"/>
-            <output_collection name="prod_merged_outputs" type="list" count="1"/>
         </test>
     </tests>
-    <help format="markdown"><![CDATA[
-SmartTile exposes four tasks: tile/subsample, merge segmented tiles, remap predictions to originals, and create prod-merged products from enriched originals.
+    <help format="markdown">
+**SmartTile** covers three common steps when working with tiled point clouds and per-point predictions:
 
-Merge requires the tile bounds JSON created by the tile task. Optional tree sidecar files must be the `*_trees.txt` and `*_trees_info.txt` outputs from `3dtrees_raycloudtools`; when supplied, SmartTile filters and returns them and keeps tile-local instance IDs.
+1. **Tile**: normalize to COPC, create tiles, and write two subsampled outputs.
+2. **Filter**: remove overlap-only/border-zone instances from segmented tiles (optionally followed by a remap).
+3. **Remap**: transfer selected dimensions from segmented tiles back onto originals (and optionally onto a subsampled target set).
 
-Prod-merged outputs can be LAZ, COPC LAZ, or binary PLY. COPC LAZ is selected with the SmartTile format token `copc.laz` and returned to Galaxy as `laz`; PLY is returned as `plybinary`.
-    ]]></help>
+**General tips**
+
+- For best matching, use filenames (element identifiers) that contain tile IDs like `c00_r01`.
+- These inputs expect LAZ/LAS (and optional tree TXT). If your history/collection also contains mesh `.ply` files, keep them separate to avoid Galaxy format errors.
+- The tool uses Galaxy slots for parallelism where available.
+- `Chunk size (points)` is the main performance knob: larger chunks reduce overhead but may increase memory use.
+
+**Tile**
+
+- SmartTile first builds a COPC-normalized cache of your inputs while preserving all source dimensions.
+- It then creates overlapping tiles and writes two subsampled output collections.
+- `Reduce dimensions in subsampled outputs` only affects the subsampled outputs, not the internal COPC cache.
+- `Write resolution 1 as COPC (.copc.laz)` only affects the first subsampled output collection (default: enabled).
+- `Write resolution 2 as COPC (.copc.laz)` only affects the second subsampled output collection (default: disabled).
+
+**Filter**
+
+- Removes instances that only exist in overlap/border zones and keeps tile-core ownership.
+- `Small cluster reassignment` (default: enabled) can merge/reassign tiny surviving instances.
+- If you choose “Also remap…”, pick **Remap target files** (originals only, targets only, or both), then remap the filtered dimensions onto the selected collections.
+
+**Remap**
+
+- Default behavior transfers all *extra* dimensions from the source segmented tiles.
+- If you set **Dimensions to transfer (optional allowlist)**, it becomes a strict allowlist and may include both standard and extra dimensions (comma-separated, e.g. `PredInstance,Intensity`).
+- COPC-safe naming: dimension names starting with a digit are sanitized, so a requested `3DT_*` dimension may appear as `TDT_*` in outputs.
+
+**Outputs**
+
+- Tiling: two subsampled collections, a COPC-normalized original collection, a preview PNG, and a tile layout JSON.
+- Filtering: filtered tiles plus (optional) filtered tree TXT sidecars.
+- Remapping: originals (and optional targets) with transferred dimensions, plus an optional merged LAZ output.
+    </help>
     <creator>
         <person name="Kilian Gerberding" email="kilian.gerberding@geosense.uni-freiburg.de" identifier="0009-0002-5001-2571"/>
         <organization name="3Dtrees-Team, University of Freiburg" url="https://github.com/3dTrees-earth"/>
     </creator>
     <citations>
         <citation type="bibtex">
-            @misc{3dtrees_smart_tile, title = {3D Trees SmartTile Tool}, author = {3D Trees Project}, year = {2026}}
+            @misc{3dtrees_tile_merge, title = {3D Trees Tile and Merge Tool}, author = {3D Trees Project}, year = {2025}}
         </citation>
     </citations>
 </tool>


### PR DESCRIPTION
## Summary
- revert PR #1910 for the SmartTile Galaxy wrapper
- restore the wrapper tokens to SmartTile `2.1.0+galaxy0`
- restore the wrapper container reference to `ghcr.io/3dtrees-earth/3dtrees_smart_tile:@TOOL_VERSION@`

## Reason
This stops SmartTile v2.2 from being advertised as the latest ToolShed wrapper revision while the production rollout is paused.

## Validation
- inspected `tools/3dtrees_smart_tile/smart_tile.xml`
- confirmed `@TOOL_VERSION@ = 2.1.0`
- confirmed `@VERSION_SUFFIX@ = 0`

## Merge policy
Draft only. Do not merge without explicit approval from Kilian.
