### PR TITLE
Request L40S GPU for ForestMamba

### DIFF
--- a/tools/3dtrees_forestmamba/forestmamba.xml
+++ b/tools/3dtrees_forestmamba/forestmamba.xml
@@ -4,10 +4,13 @@
     </description>
     <macros>
         <token name="@TOOL_VERSION@">1.0.0</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
     </macros>
     <requirements>
         <container type="docker">ghcr.io/3dtrees-earth/3dtrees_forestmamba:@TOOL_VERSION@</container>
+        <resource type="cuda_device_count_min">1</resource>
+        <resource type="cuda_device_count_max">1</resource>
+        <resource type="cuda_compute_capability">8.9</resource>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
         mkdir -p output_dir work_dir &&


### PR DESCRIPTION
## What changed

- Add ForestMamba resource requirements for one CUDA device.
- Require CUDA compute capability 8.9, matching NVIDIA L40S/Ada-class GPUs and excluding Tesla T4.
- Bump the Galaxy wrapper suffix to `+galaxy1`.

## Why

ForestMamba should be routed away from Tesla T4 GPUs and onto L40S-capable GPU nodes. Galaxy wrapper resource metadata is schema-limited, so this uses the valid CUDA capability requirement rather than an exact GPU model field.

## Validation

- `planemo lint tools/3dtrees_forestmamba/forestmamba.xml`
- XML parse check with Python `xml.etree.ElementTree`

Note: `planemo` prints a local optional `h5py`/NumPy binary compatibility warning while loading assertion modules, but the targeted lint exits successfully.
