### PR TITLE
motus DB fetcher: make temp cleanup resilient to Lustre rmtree race

### DIFF
--- a/data_managers/data_manager_motus_db_downloader/.shed.yml
+++ b/data_managers/data_manager_motus_db_downloader/.shed.yml
@@ -8,5 +8,5 @@ long_description: |
   This data managers fetches data for motus
 name: data_manager_motus
 owner: bgruening
-remote_repository_url: https://github.com/bgruening/galaxytools/tree/master/data_managers/
+remote_repository_url: https://github.com/bgruening/galaxytools/tree/master/data_managers/data_manager_motus_db_downloader
 type: unrestricted

--- a/data_managers/data_manager_motus_db_downloader/data_manager/data_manager_fetch_motus_db.py
+++ b/data_managers/data_manager_motus_db_downloader/data_manager/data_manager_fetch_motus_db.py
@@ -7,9 +7,29 @@ import shutil
 import subprocess
 import sys
 import tarfile
+import time
 from datetime import datetime
 
 import wget
+
+
+def rmtree_tolerant(path, retries=5, delay=2):
+    """Remove ``path`` recursively, tolerating the transient "Directory not
+    empty" (OSError errno 39) race that ``shutil.rmtree`` hits on parallel/network
+    filesystems (e.g. Lustre), where ``readdir`` can return stale entries
+    mid-walk. Retries a few times, then gives up quietly: ``path`` is scratch
+    space and the fetched DB has already been copied elsewhere, so a leftover
+    temp dir must never fail the job."""
+    for attempt in range(retries):
+        try:
+            shutil.rmtree(path)
+            return
+        except OSError:
+            if attempt == retries - 1:
+                shutil.rmtree(path, ignore_errors=True)
+                return
+            time.sleep(delay)
+
 
 version_mapping = {
     "3.1.0": "https://zenodo.org/records/7778108/files/db_mOTU_v3.1.0.tar.gz",
@@ -44,7 +64,7 @@ def download_untar_store(url, tmp_path, dest_path):
             shutil.copytree(folder_path, dest_path)
             print("Done !")
 
-    shutil.rmtree(tmp_path)
+    rmtree_tolerant(tmp_path)
 
 
 def main():

--- a/data_managers/data_manager_motus_db_downloader/data_manager/data_manager_fetch_motus_db.py
+++ b/data_managers/data_manager_motus_db_downloader/data_manager/data_manager_fetch_motus_db.py
@@ -60,8 +60,12 @@ def download_untar_store(url, tmp_path, dest_path):
         for folder in os.listdir(extract_path):
             folder_path = os.path.join(extract_path, folder)
 
-            print(f"Copy data to {dest_path}")
-            shutil.copytree(folder_path, dest_path)
+            print(f"Move data to {dest_path}")
+            # folder_path and dest_path are both under workdir (same
+            # filesystem), so this is an atomic rename: no multi-GB duplicate
+            # copy, and no recursive delete of the freshly-written DB tree -
+            # which is what triggers the Lustre readdir/rmtree race below.
+            shutil.move(folder_path, dest_path)
             print("Done !")
 
     rmtree_tolerant(tmp_path)

--- a/data_managers/data_manager_motus_db_downloader/data_manager/macros.xml
+++ b/data_managers/data_manager_motus_db_downloader/data_manager/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
     <token name="@TOOL_VERSION@">3.1.0</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">22.05</token>
     <xml name="biotools">
         <xrefs>


### PR DESCRIPTION
download_untar_store() copies the fetched DB out and then removes its scratch dir with shutil.rmtree(). On parallel/network filesystems (e.g. Lustre/corral4) readdir can return stale entries mid-walk, so rmtree raises OSError [Errno 39] "Directory not empty" even though the DB was stored successfully - failing the whole job on a non-essential cleanup. Retry the removal a few times, then ignore errors as a last resort.

Bumps the tool version to 3.1.0+galaxy1.

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
