### PR TITLE
Use streaming and handle reasoning models in LLM Hub tool

### DIFF
--- a/tools/llm_hub/llm_hub.py
+++ b/tools/llm_hub/llm_hub.py
@@ -150,25 +150,131 @@ retryable_errors = (
     InternalServerError,
 )
 
+# Timeouts on a long generation usually mean the work exceeds the per-request
+# budget, so re-sending reproduces the same timeout.  Cap timeout retries
+# separately (other transient errors keep the full max_retries budget).
+max_timeout_retries = int(os.environ.get("MAX_TIMEOUT_RETRIES") or config.get("MAX_TIMEOUT_RETRIES", 1))
+timeout_attempts = 0
+
+# We send no max_tokens: a fixed cap is dangerous for reasoning models (e.g.
+# OpenAI o-series, DeepSeek-R1, GLM thinking models), which spend a large,
+# unpredictable token budget on chain-of-thought before emitting any answer, so
+# a small cap yields finish_reason='length' with empty content.  Rely on the
+# model/proxy default instead; truncation is surfaced explicitly below.
+
+
+def stream_completion():
+    """Run one streaming chat completion. Returns (answer_text, finish_reason).
+
+    Streaming keeps the connection alive token-by-token (reasoning models stream
+    their chain-of-thought continuously), so request_timeout bounds inter-chunk
+    idle rather than total walltime -- the fix for the 600s idle timeout that
+    killed long non-streaming jobs.  The answer arrives on `content`;
+    `reasoning_content` (chain-of-thought, absent on non-reasoning models) is
+    ignored since a Galaxy tool produces a single dataset.
+    """
+    api_params = {"model": model, "messages": messages, "stream": True}
+    if temperature is not None:
+        api_params["temperature"] = temperature
+
+    answer_parts = []
+    finish_reason = None
+    with client.chat.completions.create(**api_params) as stream:
+        for chunk in stream:
+            if not chunk.choices:
+                continue
+            choice = chunk.choices[0]
+            delta = choice.delta
+            piece = getattr(delta, "content", None)
+            if piece:
+                answer_parts.append(piece)
+            # Discard reasoning_content (chain-of-thought); keep only the answer.
+            _ = getattr(delta, "reasoning_content", None)
+            if choice.finish_reason is not None:
+                finish_reason = choice.finish_reason
+    return "".join(answer_parts), finish_reason
+
+
 for attempt in range(max_retries):
     try:
-        api_params = {"model": model, "messages": messages}
-        if temperature is not None:
-            api_params["temperature"] = temperature
+        answer, finish_reason = stream_completion()
 
-        response = client.chat.completions.create(**api_params)
+        # An empty answer is never a usable dataset -- fail loudly before
+        # writing instead of silently emitting a blank output.md.
+        if not answer:
+            if finish_reason == "length":
+                sys.exit(
+                    "The model exhausted its token budget before producing an "
+                    "answer (finish_reason='length', empty content). The input "
+                    "is likely too large for the model/proxy token limit; split "
+                    "it into smaller chunks and re-run."
+                )
+            sys.exit(
+                "The model returned an empty response with no answer content "
+                f"(finish_reason={finish_reason!r}). The upstream model/proxy "
+                "may have dropped the stream; try again or use a different model."
+            )
+
+        # Warn (but still write) when the result may be partial: a token-budget
+        # cutoff, upstream content filtering, or a stream that ended without an
+        # explicit stop signal.
+        if finish_reason == "length":
+            print(
+                "WARNING: model output was truncated (finish_reason='length'). "
+                "The written file is a PARTIAL result. For large inputs, split "
+                "them into smaller chunks and re-run.",
+                file=sys.stderr,
+            )
+        elif finish_reason == "content_filter":
+            print(
+                "WARNING: the model output was filtered by the upstream "
+                "model/proxy (finish_reason='content_filter'). The written file "
+                "may be partial or altered; please verify and re-run if needed.",
+                file=sys.stderr,
+            )
+        elif finish_reason is None:
+            print(
+                "WARNING: the stream ended without an explicit stop signal "
+                "(finish_reason is None). The written result may be incomplete; "
+                "please verify and re-run if needed.",
+                file=sys.stderr,
+            )
+
         with open("output.md", "w") as f:
-            f.write(response.choices[0].message.content or "")
+            f.write(answer)
         break
+    except APITimeoutError as e:
+        timeout_attempts += 1
+        if attempt == max_retries - 1 or timeout_attempts > max_timeout_retries:
+            sys.exit(
+                f"Stopped after {timeout_attempts} timeout(s) "
+                f"(cap {max_timeout_retries}). Last error: "
+                f"{type(e).__name__}: {e}. The request may be too large for the "
+                f"timeout budget ({request_timeout}s). Increase "
+                f"LITELLM_REQUEST_TIMEOUT or reduce the input size."
+            )
+        sleep_time = min(2**attempt + random.uniform(0, 1), max_delay)
+        print(
+            f"{type(e).__name__} encountered ({e}). Timeout attempt "
+            f"{timeout_attempts}/{max_timeout_retries}; retrying in "
+            f"{sleep_time:.2f}s...",
+            file=sys.stderr,
+        )
+        time.sleep(sleep_time)
     except retryable_errors as e:
         if attempt == max_retries - 1:
             sys.exit(
-                f"Max retries ({max_retries}) reached. Last error: {type(e).__name__}: {e}"
+                f"Max retries ({max_retries}) reached. Last error: "
+                f"{type(e).__name__}: {e}"
             )
         sleep_time = min(2**attempt + random.uniform(0, 1), max_delay)
         if isinstance(e, RateLimitError) and hasattr(e, "response") and e.response is not None:
             retry_after = e.response.headers.get("retry-after")
             if retry_after:
                 sleep_time = min(float(retry_after), max_delay)
-        print(f"{type(e).__name__} encountered ({e}). Retrying in {sleep_time:.2f} seconds...")
+        print(
+            f"{type(e).__name__} encountered ({e}). Retrying in "
+            f"{sleep_time:.2f} seconds...",
+            file=sys.stderr,
+        )
         time.sleep(sleep_time)

--- a/tools/llm_hub/llm_hub.xml
+++ b/tools/llm_hub/llm_hub.xml
@@ -2,7 +2,7 @@
     <description>Call any LLM</description>
     <macros>
         <import>macros.xml</import>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@VERSION_SUFFIX@">2</token>
         <token name="@PROFILE@">24.0</token>
     </macros>
     <requirements>


### PR DESCRIPTION
## What & why

Long-running LLM Hub jobs (e.g. full-document translations) failed with `APITimeoutError: Request timed out` after 3 retries. Two compounding causes:

1. **Non-streaming request**: `client.chat.completions.create(...)` blocked until the *entire* completion was ready, so any generation longer than `LITELLM_REQUEST_TIMEOUT` (default 600s) timed out — and the retry loop then re-sent the whole large request from scratch, reproducing the same timeout.
2. **Reasoning models**: models that expose a `reasoning_content` field (OpenAI o-series, DeepSeek-R1, GLM thinking models, etc.) spend a large, unpredictable token budget on chain-of-thought *before* emitting any answer, making the wait even longer. The original code read only `message.content`, which stays empty during that phase.

## Changes

- **Streaming** (`stream=True`): token deltas keep the connection alive token-by-token, so `LITELLM_REQUEST_TIMEOUT` bounds *inter-chunk idle* rather than total generation walltime. Reasoning models stream their chain-of-thought continuously, so the connection never goes idle during the thinking phase.
- **Reasoning-model support**: accumulate only the answer (`content`) from the streaming delta; the non-standard `reasoning_content` (chain-of-thought) is accessed via `getattr` and discarded. Non-reasoning models that lack the field are unaffected (every access is guarded).
- **Explicit outcome handling** instead of silently producing a blank or truncated dataset:
  - An empty answer fails the job with an actionable message *before* writing `output.md` (no silent blank dataset).
  - `finish_reason` of `length`, `content_filter`, or `None` logs a warning when the written result may be partial.
- **No default `max_tokens`**: a fixed cap truncates reasoning models to empty `content` with `finish_reason='length'`. Rely on the model/proxy default.
- **Capped timeout retries**: new optional `MAX_TIMEOUT_RETRIES` config key (default 1), since re-sending a large request after a timeout reproduces the same timeout. Other transient errors keep the full `MAX_RETRIES` budget.
- Bump wrapper version to `2.41.1+galaxy2`.

## Testing

Verified end-to-end against **all 34 text/multimodal models** in the `genai_models.loc` of a live two-provider deployment (uni-freiburg + e-infra.cz), using a real subtitle-translation task — all return exit 0 with correct output, including slow reasoning models (e.g. `deepseek-v4-pro-thinking` ~108s, `deepseek-thinking` ~103s). Streaming kept the connection alive throughout; no `APITimeoutError`.

Failure paths also exercised:
- Empty answer on `finish_reason='length'` → exit 1, actionable message, no blank file written.
- Partial content + `length` → exit 0, partial file + stderr warning.
- Non-numeric `MAX_TIMEOUT_RETRIES` env → handled cleanly (no traceback).

## Notes

- This is a **behavior change**: an empty LLM response now fails the job (exit non-zero) instead of silently writing a blank dataset. An empty output is not usable by downstream tools, so failing loudly is the intended improvement. With `detect_errors='exit_code'` this surfaces clearly in Galaxy.
- Streaming cannot solve Galaxy's outer job walltime — a pathologically huge input can still exceed it. The truncation/empty messages now point users at splitting large inputs into chunks.
- No new dependencies; `openai` and `pyyaml` already required.

## Contributor checklist

* [x] I have read the CONTRIBUTING.md document and this tool is appropriate for the repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)