### PR TITLE
gxy-tool-bot: use github.event.repository.default_branch instead of hardcoded main

### DIFF
--- a/.github/workflows/gxy-on-pr-feedback.yml
+++ b/.github/workflows/gxy-on-pr-feedback.yml
@@ -12,9 +12,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
-      - name: Restore config from main
+      - name: Restore config from default branch
         run: |
-          git fetch origin main
+          git fetch origin ${{ github.event.repository.default_branch }}
           git checkout FETCH_HEAD -- .gxy-tool-bot.yml
       - name: Post status comment
         env:

--- a/.github/workflows/gxy-on-ready-to-implement.yml
+++ b/.github/workflows/gxy-on-ready-to-implement.yml
@@ -61,14 +61,15 @@ jobs:
           TOOL_DIR=$(cat generated/.tool-name)
           echo "tool_dir=$TOOL_DIR" >> $GITHUB_OUTPUT
           BRANCH="tool-bot/issue-${{ github.event.issue.number }}"
-          git fetch origin main
+          DEFAULT_BRANCH=${{ github.event.repository.default_branch }}
+          git fetch origin "$DEFAULT_BRANCH"
           # Check if branch already exists (re-run scenario)
           if git ls-remote --exit-code --heads origin "$BRANCH" 2>/dev/null; then
             git fetch origin "$BRANCH"
-            git checkout -B "$BRANCH" origin/main
+            git checkout -B "$BRANCH" "origin/$DEFAULT_BRANCH"
             REGEN=true
           else
-            git checkout -b "$BRANCH" origin/main
+            git checkout -b "$BRANCH" "origin/$DEFAULT_BRANCH"
             REGEN=false
           fi
           # Remove old tool files if they exist (clean overwrite)
@@ -107,7 +108,7 @@ jobs:
             fi
             gh pr create \
               --head "$BRANCH" \
-              --base main \
+              --base "$DEFAULT_BRANCH" \
               --title "$TOOL_DIR: auto-generated tool wrapper (issue #${{ github.event.issue.number }})" \
               --body "$PR_BODY"
             gh issue comment ${{ github.event.issue.number }} --body "✅ Tool generated successfully and PR opened!"


### PR DESCRIPTION
Fixes 'fatal: couldn't find remote ref main' on repos with master as default branch.

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
