### PR TITLE
Bump gxy-tool-bot to v0.1.2 and add tool_owner config

### DIFF
--- a/.github/workflows/gxy-on-pr-feedback.yml
+++ b/.github/workflows/gxy-on-pr-feedback.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: pip install --no-cache-dir gxy-tool-bot==0.1.1
+      - run: pip install --no-cache-dir gxy-tool-bot==0.1.2
       - run: pip install "planemo>=0.75.43"
       - name: Remove address-feedback label
         env:

--- a/.github/workflows/gxy-on-ready-to-implement.yml
+++ b/.github/workflows/gxy-on-ready-to-implement.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: pip install --no-cache-dir gxy-tool-bot==0.1.1
+      - run: pip install --no-cache-dir gxy-tool-bot==0.1.2
       - run: pip install "planemo>=0.75.43"
       - name: Remove retry-generate and generation-failed labels
         if: github.event.label.name == 'retry-generate'

--- a/.github/workflows/gxy-on-tool-request.yml
+++ b/.github/workflows/gxy-on-tool-request.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: pip install --no-cache-dir gxy-tool-bot==0.1.1
+      - run: pip install --no-cache-dir gxy-tool-bot==0.1.2
       - name: Remove retry-plan and generation-failed labels
         if: github.event.action == 'labeled'
         env:

--- a/.gxy-tool-bot.yml
+++ b/.gxy-tool-bot.yml
@@ -10,6 +10,8 @@ api:
   max_context_chars: 100000
   read_timeout: 600
 
+tool_owner: bgruening
+
 exemplars:
   - url: https://raw.githubusercontent.com/galaxyproject/tools-iuc/main/tools/bcftools/bcftools_view.xml
     macros: https://raw.githubusercontent.com/galaxyproject/tools-iuc/main/tools/bcftools/macros.xml


### PR DESCRIPTION
just a note, existing prs feedback flow i think will keep using the version in their branch (v0.1.1)

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
