### PR TITLE
Switch bot model from deepseek-thinking to glm

### DIFF
--- a/.gxy-tool-bot.yml
+++ b/.gxy-tool-bot.yml
@@ -1,6 +1,6 @@
 api:
   base_url: https://llm.ai.e-infra.cz
-  model: deepseek-thinking
+  model: glm
   fallback_models:
     - agentic
     - mini


### PR DESCRIPTION
deepseek-thinking is not currently available on llm.ai.e-infra.cz. glm is an alias that resolves to the latest GLM version.

FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
