### PR TITLE
mOTUs DB fetcher: deterministic default identifier + value override (+galaxy2)

### DIFF
--- a/data_managers/data_manager_motus_db_downloader/data_manager/data_manager_fetch_motus_db.py
+++ b/data_managers/data_manager_motus_db_downloader/data_manager/data_manager_fetch_motus_db.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 import tarfile
 import time
-from datetime import datetime
+from urllib.request import urlopen
 
 import wget
 
@@ -36,6 +36,19 @@ version_mapping = {
     "3.0.1": "https://zenodo.org/records/5140350/files/db_mOTU_v3.0.1.tar.gz",
     "3.0.0": "https://zenodo.org/records/5012106/files/db_mOTU_v3.0.0.tar.gz",
 }
+
+
+def zenodo_publication_date(file_url):
+    """Return the publication date (YYYY-MM-DD) of the Zenodo record hosting
+    ``file_url`` (``.../records/<record_id>/files/<name>``). Used to derive a
+    deterministic default DB identifier from the record itself rather than from
+    the wall-clock time of the build."""
+    record_id = file_url.split("/records/")[1].split("/")[0]
+    with urlopen(
+        f"https://zenodo.org/api/records/{record_id}"
+    ) as fh:  # noqa: S310 (fixed https host)
+        record = json.load(fh)
+    return record["metadata"]["publication_date"]
 
 
 def download_untar_store(url, tmp_path, dest_path):
@@ -83,6 +96,17 @@ def main():
         action="store_true",
         help="option to test the script with an lighted database",
     )
+    parser.add_argument(
+        "--value",
+        dest="value",
+        action="store",
+        default=None,
+        help=(
+            "Override the data-table value / on-disk directory name. Defaults to "
+            "db_from_<Zenodo publication date>. Set it to reproduce or match an "
+            "existing entry from another server."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -95,11 +119,16 @@ def main():
     workdir = params["output_data"][0]["extra_files_path"]
     os.mkdir(workdir)
 
-    time = datetime.utcnow().strftime("%Y-%m-%dT%H%M%SZ")
-    db_value = "db_from_{0}".format(time)
+    url = version_mapping[args.version]
+    # Default the identifier to the Zenodo record's publication date so it is
+    # deterministic/reproducible across builds; an explicit --value overrides it
+    # (e.g. to match an existing entry already published on another server).
+    if args.value:
+        db_value = args.value
+    else:
+        db_value = "db_from_{0}".format(zenodo_publication_date(url))
     db_path = os.path.join(workdir, db_value)
     tmp_path = os.path.join(workdir, "tmp")
-    url = version_mapping[args.version]
 
     # create DB
     if args.test:  # the test only checks that the pharokka download script is available
@@ -135,7 +164,7 @@ def main():
             "motus_db_versioned": {
                 "value": db_value,
                 "version": args.version,
-                "name": f"mOTUs DB version {args.version} downloaded at {datetime.now()}",
+                "name": f"mOTUs DB version {args.version} ({db_value})",
                 "path": db_path,
             }
         }

--- a/data_managers/data_manager_motus_db_downloader/data_manager/macros.xml
+++ b/data_managers/data_manager_motus_db_downloader/data_manager/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
     <token name="@TOOL_VERSION@">3.1.0</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">2</token>
     <token name="@PROFILE@">22.05</token>
     <xml name="biotools">
         <xrefs>

--- a/data_managers/data_manager_motus_db_downloader/data_manager/motus_db_fetcher.xml
+++ b/data_managers/data_manager_motus_db_downloader/data_manager/motus_db_fetcher.xml
@@ -10,7 +10,10 @@
 
     <command detect_errors="exit_code">
     <![CDATA[
-        python '$__tool_directory__/data_manager_fetch_motus_db.py' --out '${out_file}' --version '${version}' 
+        python '$__tool_directory__/data_manager_fetch_motus_db.py' --out '${out_file}' --version '${version}'
+        #if str($db_value).strip()
+            --value '${db_value}'
+        #end if
         $test_data_manager
     ]]>
     </command>
@@ -23,18 +26,43 @@
         <option value="3.0.1">3.0.1</option>
         <option value="3.0.0">3.0.0</option>
     </param>
+    <param name="db_value" type="text" optional="true" value="" label="Database identifier override"
+        help="Value stored in the data table and used as the on-disk directory name. Leave empty to default to db_from_&lt;Zenodo publication date&gt; (e.g. db_from_2023-03-28). Set it to reproduce or match an existing entry from another server (e.g. db_from_2026-04-27T094930Z).">
+        <sanitizer invalid_char="">
+            <valid initial="string.ascii_letters,string.digits">
+                <add value="_"/>
+                <add value="-"/>
+                <add value=":"/>
+                <add value="."/>
+            </valid>
+        </sanitizer>
+    </param>
 
     </inputs>
     <outputs>
         <data format="data_manager_json" name="out_file" />
     </outputs>
     <tests>
+    <!-- default identifier: derived from the Zenodo record's publication date -->
     <test expect_num_outputs="1">
         <param name="test_data_manager" value="--test"/>
         <param name="version" value="3.1.0"/>
         <output name="out_file">
                 <assert_contents>
-                    <has_text text="mOTUs DB version 3.1.0 downloaded at"/>
+                    <has_text text="mOTUs DB version 3.1.0"/>
+                    <has_text text="db_from_2023-03-28"/>
+                </assert_contents>
+        </output>
+    </test>
+    <!-- explicit identifier override -->
+    <test expect_num_outputs="1">
+        <param name="test_data_manager" value="--test"/>
+        <param name="version" value="3.1.0"/>
+        <param name="db_value" value="db_from_2026-04-27T094930Z"/>
+        <output name="out_file">
+                <assert_contents>
+                    <has_text text="mOTUs DB version 3.1.0"/>
+                    <has_text text="db_from_2026-04-27T094930Z"/>
                 </assert_contents>
         </output>
     </test>


### PR DESCRIPTION
### What

The mOTUs DB identifier — the `motus_db_versioned` data-table **value**, which is also used as the on-disk directory name — was generated from the job's wall-clock time:

```python
time = datetime.utcnow().strftime("%Y-%m-%dT%H%M%SZ")
db_value = "db_from_{0}".format(time)
```

So every build of the *same* mOTUs release produced a different `db_from_<timestamp>`, and no two servers (or two rebuilds on one server) could ever agree on a value for a given DB. That makes the reference data non-reproducible and breaks portability of workflows/entries that pin a specific value.

### Change

- **Deterministic default**: derive the identifier from the Zenodo record's `publication_date` instead of the build time → `db_from_<YYYY-MM-DD>` (e.g. `db_from_2023-03-28` for 3.1.0, `db_from_2021-07-27` for 3.0.1, `db_from_2021-04-26` for 3.0.0). Same release → same value, every time, everywhere.
- **Override**: add an optional `--value` parameter (empty by default) so an admin can reproduce or match an entry already published on another server (e.g. `db_from_2026-04-27T094930Z`).
- Bump to `+galaxy2`.

Two tests: the default (asserts `db_from_2023-03-28`) and an explicit override.

### Why

We're building the mOTUs DB as a reference-data bundle for `idc.galaxyproject.org` (shared via CVMFS) and need the published value to match what already exists on usegalaxy.eu (`db_from_2026-04-27T094930Z`) rather than minting a fresh timestamp each build. The deterministic default also makes any future rebuild reproducible.
