### PR TITLE
Update owner of webatlas tools

### DIFF
--- a/tools/webatlas/.shed.yml
+++ b/tools/webatlas/.shed.yml
@@ -1,5 +1,5 @@
 name: webatlas
-owner: iuc
+owner: bgruening
 description: The Galaxy WebAtlas tools to process spatial and single-cell experiment data for visualisation in a web browser using Vitessce.
 homepage_url: https://github.com/haniffalab/webatlas-pipeline
 long_description: The Galaxy WebAtlas tools provide a framework for processing spatial and single-cell experiment data, enabling visualisation with Vitessce.


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [x] This PR does something else (explain below)

The owner was wrongly added as iuc.

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
