### PR TITLE
Sync CI workflows with tools-iuc

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ env:
 jobs:
   setup:
     name: Setup cache and determine changed repositories
-    if: ${{ github.repository_owner == 'galaxyproject' }}
+    if: ${{ github.repository_owner == 'bgruening' }}
     runs-on: ubuntu-latest
     outputs:
       galaxy-head-sha: ${{ steps.get-galaxy-sha.outputs.galaxy-head-sha }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,12 +7,12 @@ on:
     types: [run-all-tool-tests-command]
 env:
   GALAXY_FORK: galaxyproject
-  GALAXY_BRANCH: release_26.0
+  GALAXY_BRANCH: release_26.1
   MAX_CHUNKS: 40
 jobs:
   setup:
     name: Setup cache and determine changed repositories
-    if: ${{ github.repository_owner == 'bgruening' }}
+    if: ${{ github.repository_owner == 'galaxyproject' }}
     runs-on: ubuntu-latest
     outputs:
       galaxy-head-sha: ${{ steps.get-galaxy-sha.outputs.galaxy-head-sha }}
@@ -43,11 +43,11 @@ jobs:
     - name: Determine latest commit in the Galaxy repo
       id: get-galaxy-sha
       run: echo "galaxy-head-sha=$(git ls-remote https://github.com/${{ steps.get-fork-branch.outputs.fork }}/galaxy refs/heads/${{ steps.get-fork-branch.outputs.branch }} | cut -f1)" >> $GITHUB_OUTPUT
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache .cache/pip
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       id: cache-pip
       with:
         path: ~/.cache/pip
@@ -56,7 +56,7 @@ jobs:
     # are not available as wheels, pip will build a wheel for them, which can be cached.
     - name: Install wheel
       run: pip install wheel
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         persist-credentials: false
     - name: Fake a Planemo run to update cache and determine commit range, repositories, and chunks
@@ -84,14 +84,14 @@ jobs:
       matrix:
         python-version: ['3.11']
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         persist-credentials: false
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache .cache/pip
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       id: cache-pip
       with:
         path: ~/.cache/pip
@@ -132,14 +132,14 @@ jobs:
         ports:
           - 5432:5432
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         persist-credentials: false
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache .cache/pip
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       id: cache-pip
       with:
         path: ~/.cache/pip
@@ -184,11 +184,11 @@ jobs:
     - uses: actions/download-artifact@v8
       with:
         path: artifacts
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache .cache/pip
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       id: cache-pip
       with:
         path: ~/.cache/pip

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -451,12 +451,13 @@ jobs:
     needs: [deploy]
     if: ${{ always() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) && github.repository_owner == 'bgruening' }}
     runs-on: ubuntu-latest
-    # pull-requests:read for the PR lookup, issues:write because commenting by
-    # issue number goes through the issues API. Needed when secrets.PAT is
-    # unset and the step falls back to github.token.
+    # pull-requests:write because the comment target is always a pull request
+    # -- the number comes from /commits/{sha}/pulls -- and create-or-update-comment
+    # documents GITHUB_TOKEN as needing (issues: write, pull-requests: write).
+    # Needed when secrets.PAT is unset and the step falls back to github.token.
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: write
     steps:
     # report to the PR if deployment failed

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,7 +17,7 @@ on:
       - '*'
 env:
   GALAXY_FORK: galaxyproject
-  GALAXY_BRANCH: release_26.0
+  GALAXY_BRANCH: release_26.1
   MAX_CHUNKS: 4
   MAX_FILE_SIZE: 1M
 concurrency:
@@ -59,17 +59,17 @@ jobs:
     - name: Determine latest commit in the Galaxy repo
       id: get-galaxy-sha
       run: echo "galaxy-head-sha=$(git ls-remote https://github.com/${{ env.GALAXY_FORK }}/galaxy refs/heads/${{ env.GALAXY_BRANCH }} | cut -f1)" >> $GITHUB_OUTPUT
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache .cache/pip
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       id: cache-pip
       with:
         path: ~/.cache/pip
         key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ steps.get-galaxy-sha.outputs.galaxy-head-sha }}
     - name: Cache .planemo
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       id: cache-planemo
       with:
         path: ~/.planemo
@@ -80,7 +80,7 @@ jobs:
       run: pip install wheel
     - name: Install flake8
       run: pip install flake8 flake8-import-order
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
         persist-credentials: false
@@ -109,46 +109,67 @@ jobs:
     needs: setup
     if: ${{ needs.setup.outputs.repository-list != '' || needs.setup.outputs.tool-list != '' }}
     runs-on: ubuntu-latest
+    # The label lookup below needs pull-requests:read. Declared explicitly so
+    # the job does not depend on the repository's default workflow permissions,
+    # which may be restricted to contents:read.
+    permissions:
+      contents: read
+      pull-requests: read
     strategy:
       fail-fast: false
       matrix:
         python-version: ['3.11']
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         persist-credentials: false
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache .cache/pip
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       id: cache-pip
       with:
         path: ~/.cache/pip
         key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy-head-sha }}
-    - name: Find Pull Request
-      id: find-pr
-      uses: sharesight/find-github-pull-request@v1.3.0
-      with:
-        allowClosed: true
-        failIfNotFound: true
-    - name: Get labels of the PR
-      uses: snnaplab/get-labels-action@v1
-      with:
-        number: ${{ steps.find-pr.outputs.number }}
-    - name: Print PR and label info
+    # On pull_request the number is in the payload, so look the labels up
+    # directly. On push there is no number, so fall back to the PR the commit
+    # came from -- the merged PR's labels must still be honoured here, or a tool
+    # merged with skip-url-check fails lint on main and blocks the ToolShed
+    # deploy. A push with no associated PR yields no labels, i.e. full checks,
+    # rather than failing the job as the previous action did.
+    # Fetching at run time (not from the event payload) means a label added after
+    # a failed run is picked up when that run is retried.
+    - name: Get PR labels
+      id: pr-labels
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+        EVENT_NAME: ${{ github.event_name }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        SHA: ${{ github.sha }}
       run: |
-        echo number: ${{ steps.find-pr.outputs.number }}
-        echo labels: ${{ env.LABELS }}
+        # Assign first so a failing `gh api` fails the step: inside a command
+        # substitution its exit status would be masked by `echo`, leaving an
+        # empty output that silently reads as "no labels".
+        if [ "$EVENT_NAME" = "pull_request" ]; then
+          labels=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '[.labels[].name] | @json')
+        else
+          # A direct push with no associated PR yields [], i.e. full checks.
+          labels=$(gh api "repos/$REPO/commits/$SHA/pulls" --jq '[.[0].labels[]?.name] | @json')
+        fi
+        echo "json=$labels" >> "$GITHUB_OUTPUT"
     - name: Conditionally skip URL/version linter
+      env:
+        PR_LABELS: ${{ steps.pr-labels.outputs.json }}
       run: |
           set -x
 
           to_skip=()
-          if echo '${{ env.LABELS }}' | jq -e --arg s "skip-url-check" 'index($s)' > /dev/null; then
+          if echo "$PR_LABELS" | jq -e --arg s "skip-url-check" 'index($s)' > /dev/null; then
             to_skip+=("tool_urls")
           fi
-          if echo '${{ env.LABELS }}' | jq -e --arg s "skip-version-check" 'index($s)' > /dev/null; then
+          if echo "$PR_LABELS" | jq -e --arg s "skip-version-check" 'index($s)' > /dev/null; then
             to_skip+=("version_bumped")
           fi
 
@@ -184,14 +205,14 @@ jobs:
       matrix:
         python-version: ['3.11']
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         persist-credentials: false
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache .cache/pip
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       id: cache-pip
       with:
         path: ~/.cache/pip
@@ -216,14 +237,14 @@ jobs:
         os: [ubuntu-24.04]
         r-version: ['release']
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         persist-credentials: false
     - uses: r-lib/actions/setup-r@v2
       with:
         r-version: ${{ matrix.r-version }}
     - name: Cache R packages
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: ${{ env.R_LIBS_USER }}
         key: r_cache_${{ matrix.os }}_${{ matrix.r-version }}
@@ -251,7 +272,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && needs.setup.outputs.repository-list != '' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
         persist-credentials: false
@@ -295,20 +316,20 @@ jobs:
         ports:
           - 5432:5432
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         persist-credentials: false
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache .cache/pip
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       id: cache-pip
       with:
         path: ~/.cache/pip
         key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy-head-sha }}
     - name: Cache .planemo
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       id: cache-planemo
       with:
         path: ~/.planemo
@@ -353,11 +374,11 @@ jobs:
     - uses: actions/download-artifact@v8
       with:
         path: artifacts
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache .cache/pip
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       id: cache-pip
       with:
         path: ~/.cache/pip
@@ -391,20 +412,20 @@ jobs:
   deploy:
     name: Deploy
     needs: [setup, lint, combine_outputs]
-    if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) && github.repository_owner == 'bgruening' }}
+    if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) && github.repository_owner == 'galaxyproject' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ['3.11']
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         persist-credentials: false
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache .cache/pip
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       id: cache-pip
       with:
         path: ~/.cache/pip
@@ -428,19 +449,37 @@ jobs:
   deploy-report:
     name: Report deploy status
     needs: [deploy]
-    if: ${{ always() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) && github.repository_owner == 'bgruening' }}
+    if: ${{ always() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) && github.repository_owner == 'galaxyproject' }}
     runs-on: ubuntu-latest
+    # pull-requests:read for the PR lookup, issues:write because commenting by
+    # issue number goes through the issues API. Needed when secrets.PAT is
+    # unset and the step falls back to github.token.
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
     steps:
     # report to the PR if deployment failed
-    - name: Get PR object
-      uses: 8BitJonny/gh-get-current-pr@4.0.0
+    # Same lookup as the lint job. This job only runs on push, so the number has
+    # to come from the commit. No PR found means there is nothing to comment on.
+    - name: Get PR number
       id: getpr
-      with:
-        sha: ${{ github.event.after }}
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ github.sha }}
+      run: |
+        # Assign first so a failing `gh api` fails the step rather than being
+        # masked by `echo` inside a command substitution.
+        number=$(gh api "repos/$REPO/commits/$SHA/pulls" --jq '.[0].number // empty')
+        echo "number=$number" >> "$GITHUB_OUTPUT"
     - name: Create comment
+      if: steps.getpr.outputs.number != ''
       uses: peter-evans/create-or-update-comment@v5
       with:
-        token: ${{ secrets.PAT }}
+        # An explicitly empty token overrides the action's github.token default,
+        # so fall back rather than passing secrets.PAT straight through.
+        token: ${{ secrets.PAT || github.token }}
         issue-number: ${{ steps.getpr.outputs.number }}
         body: |
           Deployment status: **${{ needs.deploy.result }}**

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -412,7 +412,7 @@ jobs:
   deploy:
     name: Deploy
     needs: [setup, lint, combine_outputs]
-    if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) && github.repository_owner == 'galaxyproject' }}
+    if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) && github.repository_owner == 'bgruening' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -449,7 +449,7 @@ jobs:
   deploy-report:
     name: Report deploy status
     needs: [deploy]
-    if: ${{ always() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) && github.repository_owner == 'galaxyproject' }}
+    if: ${{ always() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) && github.repository_owner == 'bgruening' }}
     runs-on: ubuntu-latest
     # pull-requests:read for the PR lookup, issues:write because commenting by
     # issue number goes through the issues API. Needed when secrets.PAT is

--- a/.github/workflows/slash.yaml
+++ b/.github/workflows/slash.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   slashCommandDispatch:
     if: >-
-      ${{ github.repository_owner == 'galaxyproject'
+      ${{ github.repository_owner == 'bgruening'
       && contains(github.event.comment.body, '/run-all-tool-tests') }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/slash.yaml
+++ b/.github/workflows/slash.yaml
@@ -4,12 +4,19 @@ on:
     types: [created]
 jobs:
   slashCommandDispatch:
+    if: >-
+      ${{ github.repository_owner == 'galaxyproject'
+      && contains(github.event.comment.body, '/run-all-tool-tests') }}
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    env:
+      PAT: ${{ secrets.PAT }}
     steps:
       - name: Slash Command Dispatch
-        if: github.repository_owner == 'bgruening'
+        if: ${{ env.PAT != '' }}
         uses: peter-evans/slash-command-dispatch@v5
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ env.PAT }}
           commands: |
             run-all-tool-tests


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [ ] This PR updates an existing tool or tool collection
* [x] This PR does something else (explain below)

---

Syncs `ci.yaml`, `pr.yaml` and `slash.yaml` with galaxyproject/tools-iuc@99e9631e, like the earlier syncs in #1779, #1717 and #1264.

## Why

Two CI fixes landed upstream that we are missing, and both fail here every day.

**galaxyproject/tools-iuc#8281.** `deploy-report` passes `token: ${{ secrets.PAT }}` to `create-or-update-comment`. `PAT` is not set in this repo, and an empty value overrides the action's own `github.token` default, so the step fails with `Error: Parameter token or opts.auth is required`. 11 of the last 12 pushes to `master` failed this way, 8 of them only because of this, after the ToolShed deploy had already worked (for example [33746959522](https://github.com/bgruening/galaxytools/actions/runs/33746959522)).

**galaxyproject/tools-iuc#8280.** `slash.yaml` started a runner for every issue comment and then failed on the missing `PAT`. The last 8 `issue_comment` runs here are all red. It now only runs when the comment holds the command, and skips the dispatch when no PAT is set. That is what @bgruening asked for in #1944: *"should be configured that its not failing when there are not credentials, because all the tool repos will most likely not use it."*

Both also replace `sharesight/find-github-pull-request` and `8BitJonny/gh-get-current-pr` with a `gh api` call, which clears the two Node 20 warnings. The author of the first [confirmed](https://github.com/sharesight/find-github-pull-request/pull/275#issuecomment-5555560506) it is unmaintained and suggested not depending on it.

Together these close items 1 to 3 of #1944.

## Also in here

- `actions/checkout` v6 to v7, `actions/setup-python` v6 to v7, `actions/cache` v5 to v6
- `GALAXY_BRANCH` `release_26.0` to `release_26.1`, matching IUC. This changes which Galaxy release tools are tested against.

## The three commits

1. The three files copied from IUC, unchanged.
2. The four `repository_owner` conditions set back to `bgruening`.
3. `deploy-report` given `pull-requests: write`.

Commit 2 is the one to look at. The synced files carry IUC's `repository_owner == 'galaxyproject'`, which would quietly disable the deploy, report and dispatch jobs here. An earlier sync shipped exactly that twice, fixed later in 0901e22f (2022) and db11d789 (2026-02). Keeping it as its own commit makes the upstream content and our local change easy to review apart.

| File | Job |
|---|---|
| `ci.yaml:15` | setup |
| `pr.yaml:415` | deploy |
| `pr.yaml:452` | deploy-report |
| `slash.yaml:8` | dispatch, moved from step to job level by #8280 |

`GALAXY_FORK: galaxyproject` is left alone on purpose.

Commit 3 came out of reviewing this PR. The `permissions` block added by #8281 grants `pull-requests: read`, but the comment target is always a pull request, so the `github.token` fallback would have returned 403 instead of posting. Since we have no PAT, that is our only path. It is now fixed upstream too in galaxyproject/tools-iuc#8405, so the files still match.

## Not included

- `ready-for-review.yaml`, IUC only. It needs `actions/create-github-app-token` with App secrets we do not have. That is the GitHub App from #1944 item 1, still a maintainer call, so porting it would add a workflow that cannot run.
- `ci.yaml`'s two `secrets.PAT` uses stay unguarded. `ci.yaml` only runs on `schedule` or `repository_dispatch`, and both PAT steps need the dispatch payload. A dispatch only happens if `slash.yaml` already used that same secret, so `PAT` is never empty when they run and a guard would be dead code.
- `gxy-*.yml`, ours only, untouched.

## Checks

`.github/**` is in `pr.yaml`'s `paths-ignore`, so this PR does not run the workflows it edits.

- The only difference from IUC is the four `repository_owner` lines above, checked with `diff`.
- `grep repository_owner .github/workflows/*.yaml | grep galaxyproject` gives nothing.
- `actionlint` reports 4 findings. All 4 were already here before the sync and are in IUC too, so nothing new is introduced.
