### PR TITLE
bump kraken_ocr: update TOOL_VERSION to 7.1.1 and remove environment variable TORCHINDUCTOR_CACHE_DIR

### DIFF
--- a/tools/kraken_ocr/macros.xml
+++ b/tools/kraken_ocr/macros.xml
@@ -31,6 +31,7 @@
         #end if
     ]]></token>
     <token name="@RUN_KRAKEN@"><![CDATA[
+        export TORCHINDUCTOR_CACHE_DIR="\${GALAXY_SLOTS:-1}" &&
         KRAKEN_DEVICE="\${KRAKEN_DEVICE:-cpu}" &&
         kraken
             --device "\$KRAKEN_DEVICE"
@@ -46,6 +47,7 @@
             #end if
     ]]></token>
     <token name="@RUN_KRAKEN_OCR@"><![CDATA[
+        export TORCHINDUCTOR_CACHE_DIR="\${GALAXY_SLOTS:-1}" &&
         KRAKEN_DEVICE="\${KRAKEN_DEVICE:-cpu}" &&
         kraken
             --device "\$KRAKEN_DEVICE"

--- a/tools/kraken_ocr/macros.xml
+++ b/tools/kraken_ocr/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">7.1</token>
+    <token name="@TOOL_VERSION@">7.1.1</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <token name="@PROFILE@">25.1</token>
     <token name="@SET_OUTPUT_EXTENSION@"><![CDATA[
@@ -84,7 +84,6 @@
                 formatting/control sequences from breaking Galaxy's stdout/stderr rendering. -->
             <environment_variable name="TERM">dumb</environment_variable>
             <environment_variable name="FORCE_COLOR">0</environment_variable>
-            <environment_variable name="TORCHINDUCTOR_CACHE_DIR">\$_GALAXY_JOB_TMP_DIR</environment_variable>
         </environment_variables>
     </xml>
     <xml name="citations">

--- a/tools/kraken_ocr/macros.xml
+++ b/tools/kraken_ocr/macros.xml
@@ -31,10 +31,9 @@
         #end if
     ]]></token>
     <token name="@RUN_KRAKEN@"><![CDATA[
-        export TORCHINDUCTOR_CACHE_DIR="\${GALAXY_SLOTS:-1}" &&
-        KRAKEN_DEVICE="\${KRAKEN_DEVICE:-cpu}" &&
+        export TORCHINDUCTOR_CACHE_DIR="\${TORCHINDUCTOR_CACHE_DIR:-\$_GALAXY_JOB_TMP_DIR}" &&
         kraken
-            --device "\$KRAKEN_DEVICE"
+            --device "\${KRAKEN_DEVICE:-cpu}"
             --raise-on-error
             $output_format_flag
 
@@ -47,10 +46,9 @@
             #end if
     ]]></token>
     <token name="@RUN_KRAKEN_OCR@"><![CDATA[
-        export TORCHINDUCTOR_CACHE_DIR="\${GALAXY_SLOTS:-1}" &&
-        KRAKEN_DEVICE="\${KRAKEN_DEVICE:-cpu}" &&
+        export TORCHINDUCTOR_CACHE_DIR="\${TORCHINDUCTOR_CACHE_DIR:-\$_GALAXY_JOB_TMP_DIR}" &&
         kraken
-            --device "\$KRAKEN_DEVICE"
+            --device "\${KRAKEN_DEVICE:-cpu}"
             --raise-on-error
             $output_format_flag
 


### PR DESCRIPTION
Recently another [kraken (OCR)](https://pypi.org/project/kraken/) version has been released.
The corresponding conda-forge package has already been built: https://github.com/conda-forge/kraken-ocr-feedstock/pull/4

For reviewers:
-  This PR includes next to the kraken-ocr version bump the removal of the environment variable TORCHINDUCTOR_CACHE_DIR as already started here: https://github.com/bgruening/galaxytools/pull/1935 but not yet merged.
- All tests are passing locally. 9 tests are erroring out locally with `AssertionError: Staging failed: {"err_msg":"Requested extension 'mlmodel' unknown, cannot upload dataset.","err_code":400008}`
since the in the CI used galaxy version does not include these new datatypes yet. 

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
