### PR TITLE
update creator in Simorgh

### DIFF
--- a/tools/simorgh/macros.xml
+++ b/tools/simorgh/macros.xml
@@ -15,6 +15,7 @@
             <person givenName="Omid" familyName="Mokhtari" email="omid.mokhtari@inria.fr" identifier="https://orcid.org/0009-0000-8751-8117"/>
             <person givenName="Hamed" familyName="Khakzad" email="hamed.khakzad@inria.fr" identifier="https://orcid.org/0000-0002-8556-0650"/>
             <person givenName="Björn" familyName="Grüning" email="gruening@informatik.uni-freiburg.de" identifier="https://orcid.org/0000-0002-3079-6586"/>
+            <person givenName="Yasaman" familyName="Karami" email="yasaman.karami@inria.fr" identifier="https://orcid.org/0000-0001-8413-2665"/>
         </creator>
     </xml>
     <xml name="biotools">


### PR DESCRIPTION
@amisteromid mentioned that a creator is missing. This PR adds Yasaman as creator.



FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational)
* [ ] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

There are two labels that allow to ignore specific (false positive) tool linter errors:

* `skip-version-check`: Use it if only a subset of the tools has been updated in a suite.
* `skip-url-check`: Use it if github CI sees 403 errors, but the URLs work.
