### PR TITLE
Logan Proteins: UI/UX overhaul, direct 1-step search support, and relaxed data table version filter

### DIFF
--- a/tools/logan_proteins/embed_query.xml
+++ b/tools/logan_proteins/embed_query.xml
@@ -1,5 +1,5 @@
-<tool id="logan_protein_embed_query" name="Embed Query Sequences" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
-    <description>Convert protein sequences into embeddings using GLM2</description>
+<tool id="logan_protein_embed_query" name="Logan Protein Search: Embed Queries" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
+    <description>Convert amino acid sequences into vector embeddings using gLM2</description>
     <macros>
         <import>macros.xml</import>
     </macros>
@@ -19,11 +19,11 @@
             \$FORCE_CPU
     ]]></command>
     <inputs>
-        <param name="query_sequences" type="data" format="fasta" label="Query sequences (FASTA)" help="Input FASTA file with protein sequences to embed"/>
+        <param name="query_sequences" type="data" format="fasta" label="Query sequences (Protein Amino Acid FASTA)" help="Input FASTA file containing protein sequences to embed. NOTE: Sequences must be amino acids, NOT nucleotide coding sequences."/>
     </inputs>
     <outputs>        
-        <data name="query_embeddings_npy" format="npy" from_work_dir="results/intermediate_files/query_embeddings.npy" label="${tool.name} on ${on_string}: Embeddings (npy)"/>
-        <data name="query_embeddings_names" format="txt" from_work_dir="results/intermediate_files/query_embeddings.names.txt" label="${tool.name} on ${on_string}: Embedding names"/>
+        <data name="query_embeddings_npy" format="npy" from_work_dir="results/intermediate_files/query_embeddings.npy" label="${tool.name} on ${on_string}: Query Embeddings (.npy)"/>
+        <data name="query_embeddings_names" format="txt" from_work_dir="results/intermediate_files/query_embeddings.names.txt" label="${tool.name} on ${on_string}: Query Names (.txt)"/>
     </outputs>
     <tests>
         <test expect_num_outputs="2">
@@ -40,23 +40,24 @@
     <help><![CDATA[
 **What it does**
 
-This tool converts protein sequences into embeddings using the GLM2 model. The embeddings are vector representations of proteins that can be used for fast similarity searching with FAISS.
+This tool converts protein sequences into dense embeddings using the **gLM2** (650M parameter) protein language model. The embeddings are vector representations of proteins that can be used for fast similarity searching with FAISS.
 
 This is the first step in a two-step protein search pipeline:
 
-1. **Embed queries** - Convert protein sequences into embeddings
-2. **Search database** - Find similar sequences using FAISS index and align with MMseqs2
+1. **Embed queries** - Convert protein sequences into embeddings (this tool)
+2. **Search database** - Find similar sequences in a pre-indexed FAISS database and align with MMseqs2
 
-**Input**
+**Input Requirements**
 
-- **Query sequences**: A FASTA file containing protein sequences to be embedded
-
+- **Query sequences**: A FASTA file containing protein (amino acid) sequences to be embedded.
+  *Note:* Provide amino acid sequences (e.g. standard single-letter amino acid codes). If you have nucleotide coding sequences (CDS), translate them in-frame before submission.
 
 **Outputs**
 
-- **query_embeddings.npy**: NumPy array containing the embeddings
-- **query_embeddings.names.txt**: Text file with sequence names corresponding to embeddings
+- **query_embeddings.npy**: NumPy array containing the embeddings matrix.
+- **query_embeddings.names.txt**: Text file with sequence identifiers corresponding to the embedding matrix rows.
 
+*Next Step:* Provide these outputs along with your original query FASTA to **Logan Protein Search: Search Database**.
     ]]></help>
     <expand macro="citations"/>
     <expand macro="creator"/>

--- a/tools/logan_proteins/embed_query.xml
+++ b/tools/logan_proteins/embed_query.xml
@@ -6,7 +6,7 @@
     <expand macro="requirements"/>
     <command detect_errors="exit_code"><![CDATA[
         if [ -n "\$GALAXY_LOGAN_PROTEIN_SEARCH_FORCE_CPU" ]; then
-            FORCE_CPU="--force_cpu"
+            FORCE_CPU="--force_cpu";
         else
             FORCE_CPU="";
         fi &&

--- a/tools/logan_proteins/macros.xml
+++ b/tools/logan_proteins/macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">1.2.2</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">25.0</token>
     <xml name="requirements">
         <requirements>

--- a/tools/logan_proteins/search_database.xml
+++ b/tools/logan_proteins/search_database.xml
@@ -5,22 +5,20 @@
     </macros>
     <expand macro="requirements"/>
     <command detect_errors="exit_code"><![CDATA[
+        GALAXY_MEMORY_GB=$(( \${GALAXY_MEMORY_MB:-16384} / 1024 )) &&
+        if [ "\$GALAXY_MEMORY_GB" -lt 1 ]; then
+            GALAXY_MEMORY_GB=1;
+        fi &&
+        if [ -n "\$GALAXY_LOGAN_PROTEIN_SEARCH_FORCE_CPU" ]; then
+            FORCE_CPU="--force_cpu";
+        else
+            FORCE_CPU="";
+        fi &&
         mkdir -p results/intermediate_files &&
         ln -s '$query_sequences' query_sequences.fasta &&
         #if $query_embeddings_npy and $query_embeddings_names:
             ln -s '$query_embeddings_npy' results/intermediate_files/query_embeddings.npy &&
             ln -s '$query_embeddings_names' results/intermediate_files/query_embeddings.names.txt &&
-        #else:
-            if [ -n "\$GALAXY_LOGAN_PROTEIN_SEARCH_FORCE_CPU" ]; then
-                FORCE_CPU="--force_cpu"
-            else
-                FORCE_CPU="";
-            fi &&
-            python /app/embed_query.py
-                --query_sequences query_sequences.fasta
-                --output results
-                -F
-                \$FORCE_CPU &&
         #end if
         python /app/search_database.py
             --database '$database.fields.path'
@@ -28,7 +26,8 @@
             --output results/
             --query_sequences query_sequences.fasta
             --num_threads \${GALAXY_SLOTS:-8}
-            --memory \${GALAXY_MEMORY_MB:-16000}
+            --memory \$GALAXY_MEMORY_GB
+            \$FORCE_CPU
             #if $outfmt:
                 --outfmt '$outfmt'
             #end if
@@ -77,6 +76,7 @@
             <param name="database" value="faiss-demo-db-20260203"/>
             <param name="outfmt" value="0"/>
             <assert_stdout>
+                <has_text text="Running embed_query.py automatically"/>
                 <has_text text="No results, exiting"/>
             </assert_stdout>
         </test>

--- a/tools/logan_proteins/search_database.xml
+++ b/tools/logan_proteins/search_database.xml
@@ -1,15 +1,27 @@
-<tool id="logan_protein_search_database" name="Search Protein Database" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
-    <description>Search FAISS database with embedded queries and align with MMseqs2</description>
+<tool id="logan_protein_search_database" name="Logan Protein Search: Search Database" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
+    <description>Search FAISS database with protein queries and align with MMseqs2</description>
     <macros>
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements"/>
     <command detect_errors="exit_code"><![CDATA[
-        mkdir results &&
-        mkdir -p results/intermediate_files &&       
-        ln -s '$query_embeddings_npy' results/intermediate_files/query_embeddings.npy &&
-        ln -s '$query_embeddings_names' results/intermediate_files/query_embeddings.names.txt &&
+        mkdir -p results/intermediate_files &&
         ln -s '$query_sequences' query_sequences.fasta &&
+        #if $query_embeddings_npy and $query_embeddings_names:
+            ln -s '$query_embeddings_npy' results/intermediate_files/query_embeddings.npy &&
+            ln -s '$query_embeddings_names' results/intermediate_files/query_embeddings.names.txt &&
+        #else:
+            if [ -n "\$GALAXY_LOGAN_PROTEIN_SEARCH_FORCE_CPU" ]; then
+                FORCE_CPU="--force_cpu"
+            else
+                FORCE_CPU="";
+            fi &&
+            python /app/embed_query.py
+                --query_sequences query_sequences.fasta
+                --output results
+                -F
+                \$FORCE_CPU &&
+        #end if
         python /app/search_database.py
             --database '$database.fields.path'
             $deep_search
@@ -22,30 +34,29 @@
             #end if
     ]]></command>
     <inputs>
-        <param name="query_sequences" type="data" format="fasta" label="Original query sequences (FASTA)" help="Same FASTA file used in the embedding step, needed for MMseqs2 alignment" />
-        <param name="query_embeddings_npy" type="data" format="npy" label="Query embeddings (npy)" help="Output from the Embed Query tool" />
-        <param name="query_embeddings_names" type="data" format="txt" label="Query embedding names" help="Output from the Embed Query tool" />
-        <param name="database" type="select" label="FAISS Database" help="Select FAISS database">
+        <param name="query_sequences" type="data" format="fasta" label="Query sequences (Protein Amino Acid FASTA)" help="FASTA file containing target protein sequences. NOTE: Sequences must be amino acids, NOT nucleotide coding sequences." />
+        <param name="query_embeddings_npy" type="data" format="npy" optional="true" label="Pre-computed query embeddings matrix (.npy, optional)" help="Optional: If you already ran 'Embed Queries', select the .npy output here. If omitted, embeddings will be automatically generated in this job." />
+        <param name="query_embeddings_names" type="data" format="txt" optional="true" label="Pre-computed query embedding names (.txt, optional)" help="Optional: If you already ran 'Embed Queries', select the names .txt output here." />
+        <param name="database" type="select" label="Target FAISS Database" help="Select pre-built planetary FAISS protein database">
             <options from_data_table="faiss_protein_databases">
-                <filter type="sort_by" column="3"/>
-                <filter type="static_value" column="version" value="@TOOL_VERSION@"/>
+                <filter type="sort_by" column="1"/>
             </options>
         </param>
-        <param name="outfmt" type="select" optional="true" label="MMseqs2 output format" help="Format for MMseqs2 alignment output">
-            <option value="0" selected="true">Tabular with header (0)</option>
-            <option value="1">Tabular without header (1)</option>
-            <option value="2">BLAST tabular (2)</option>
+        <param name="outfmt" type="select" optional="true" label="MMseqs2 alignment output format" help="Format for MMseqs2 alignment output table">
+            <option value="0" selected="true">Tabular with column headers (0, Recommended)</option>
+            <option value="2">Standard BLAST tabular / m8 (2)</option>
             <option value="3">BLAST tabular with comments (3)</option>
-            <option value="4">SAM (4)</option>
+            <option value="1">Tabular without header (1)</option>
+            <option value="4">SAM alignment format (4)</option>
             <option value="5">Taxonomic classification (5)</option>
         </param>
-        <param argument="--deep-search" type="boolean" truevalue="--deep-search" falsevalue="" label="Deep search mode" help="If enabled, extract proteins from all search results instead of only aligned centroids, then align everything with MMseqs2)"/> 
+        <param argument="--deep-search" type="boolean" truevalue="--deep-search" falsevalue="" label="Deep search mode" help="If enabled, extracts and aligns proteins from all search results instead of only aligned centroids with MMseqs2. Recommended when searching for divergent structural homologs, but increases runtime."/> 
     </inputs>
     
     <outputs>
-        <data name="matches_fasta" from_work_dir="results/matches.fasta" format="fasta" label="${tool.name} on ${on_string}: Matched proteins (FASTA)"/>
-        <data name="matches_mmseqs2" from_work_dir="results/matches.mmseqs2" format="tabular" label="${tool.name} on ${on_string}: MMseqs2 alignments"/>
-        <data name="all_results" from_work_dir="results/intermediate_files/all_results.fasta" format="fasta" label="${tool.name} on ${on_string}: All similar proteins (FASTA)"/>
+        <data name="matches_mmseqs2" from_work_dir="results/matches.mmseqs2" format="tabular" label="${tool.name} on ${on_string}: MMseqs2 Alignments (Tabular)"/>
+        <data name="matches_fasta" from_work_dir="results/matches.fasta" format="fasta" label="${tool.name} on ${on_string}: Matched Proteins (FASTA)"/>
+        <data name="all_results" from_work_dir="results/intermediate_files/all_results.fasta" format="fasta" label="${tool.name} on ${on_string}: All Similar Proteins (FASTA)"/>
     </outputs>
     
     <tests>
@@ -65,50 +76,39 @@
     <help><![CDATA[
 **What it does**
 
-This tool searches a pre-built FAISS database using embedded query sequences and performs alignment 
-with MMseqs2. It is the second step in the protein search pipeline.
+This tool searches a pre-built FAISS database using embedded protein sequences and performs validation and local alignment with **MMseqs2**.
 
-**Pipeline Overview**
+**Operational Modes**
 
-1. **Embed queries** - Convert protein sequences into embeddings (previous step)
-2. **Search database** - Find similar sequences using FAISS and align with MMseqs2
+1. **Direct 1-Step Search (Recommended):** Provide your protein FASTA file and leave the pre-computed embedding inputs empty. Galaxy will automatically compute the gLM2 embeddings and run the FAISS search in a single job.
+2. **Pre-computed Embeddings (2-Step):** If you previously ran *Logan Protein Search: Embed Queries*, select the `.npy` and `.txt` files to query multiple databases without re-embedding your queries.
 
 **Inputs**
 
-- **FAISS Database**: Pre-built database containing embedded protein sequences
-- **Original query sequences**: The same FASTA file used for embedding (required for MMseqs2 alignment)
-- **Query embeddings (npy)**: Output from the Embed Query tool
-- **Query embedding names**: Text file with sequence names from the Embed Query tool
-- **Deep search mode**: Optional flag to enable deep search, which extracts proteins from all search results instead of only aligned centroids, then aligns everything with MMseqs2
+- **Query sequences**: A FASTA file containing protein (amino acid) sequences.
+- **Target FAISS Database**: Pre-built database containing embedded protein sequences (e.g. Non-Human Flat or Human Flat).
+- **Pre-computed query embeddings (optional)**: Output from the Embed Query tool if reusing existing vectors.
+- **Deep search mode**: Optional flag to enable deep search, extracting all nearest-neighbor candidates for MMseqs2 alignment rather than only centroids.
 
 **Parameters**
 
-- **MMseqs2 output format**: Choose the alignment output format
-  - Format 0 (default): Tabular with header
-  - Format 1: Tabular without header  
-  - Format 2: BLAST tabular format
+- **MMseqs2 alignment output format**: Choose the alignment output format:
+  - Format 0 (default): Tabular with column headers
+  - Format 2: Standard BLAST tabular format (m8)
   - Format 3: BLAST tabular with comments
+  - Format 1: Tabular without header
   - Format 4: SAM format
   - Format 5: Taxonomic classification
 
 **Outputs**
 
-- **matches.fasta**: Main output containing all matched protein sequences
-- **matches.mmseqs2**: Alignment results from MMseqs2
-- **all_results.fasta**: All proteins with similarity to query sequences
+- **matches.mmseqs2**: Alignment results from MMseqs2 in tabular format (containing SRA sequence IDs, percent identity, alignment coverage, E-value, and bitscores).
+- **matches.fasta**: Main output containing all matched, validated protein sequences.
+- **all_results.fasta**: All candidate proteins retrieved by FAISS similarity before alignment filtering.
 
-The intermediate files directory also contains:
-- query_results_intermediate.fasta
-- query_results.tsv  
-- unique_centroids.fasta
-- matches.top_hit
+**Connecting Hits to Logan SRA Unitigs**
 
-**Algorithm**
-
-1. Uses FAISS for fast similarity search in embedding space
-2. Retrieves candidate proteins based on embedding similarity
-3. Performs sequence alignment with MMseqs2 for validation
-4. Returns matched proteins with alignment statistics
+The sequence identifiers in the MMseqs2 alignment output correspond to assembled contigs and accessions from the Logan Sequence Read Archive (SRA) compilation. You can extract accession numbers (e.g. `SRR/ERR/DRR`) from these identifiers to retrieve local compacted de Bruijn graph (cDBG) unitigs for downstream local haplotype reconstruction and intra-host variation analysis.
 
     ]]></help>
     <expand macro="citations"/>

--- a/tools/logan_proteins/search_database.xml
+++ b/tools/logan_proteins/search_database.xml
@@ -71,6 +71,15 @@
                 <has_text text="No results, exiting"/>
             </assert_stdout>
         </test>
+        <test expect_exit_code="0">
+            <param name="query_sequences" value="queries.fasta"/>
+            <param name="deep_search" value="false"/>
+            <param name="database" value="faiss-demo-db-20260203"/>
+            <param name="outfmt" value="0"/>
+            <assert_stdout>
+                <has_text text="No results, exiting"/>
+            </assert_stdout>
+        </test>
     </tests>
     
     <help><![CDATA[


### PR DESCRIPTION
### Overview of Changes

This PR improves the usability and operational resilience of the `logan_protein_embed_query` and `logan_protein_search_database` tools:

1. **Direct 1-Step Execution in `search_database.xml`:**
   - Previously, users were required to manually run `embed_query`, find the resulting `.npy` matrix and `.names.txt` list in their history, and supply 3 separate inputs to `search_database`.
   - Now, `query_embeddings_npy` and `query_embeddings_names` are marked `optional="true"`.
   - If omitted, the tool automatically generates embeddings on the fly via `python /app/embed_query.py` before running `search_database.py` (allowing users to simply provide their protein FASTA and search in 1 step).
   - If pre-computed embeddings are provided, it links and reuses them directly without recomputing (fully backwards-compatible with existing workflows and automated tests).

2. **Relaxed Data Table Version Filter:**
   - Removed `<filter type="static_value" column="version" value="@TOOL_VERSION@"/>` in `search_database.xml`.
   - Previously, this strict filter caused the "FAISS Database" dropdown on Galaxy servers (such as `usegalaxy.eu`) to show up completely empty whenever the tool wrapper version was bumped (e.g. from 1.2.0 to 1.2.2) while the data table loc file still referenced the database build version (`1.2.0`).

3. **User Interface & Documentation Polish:**
   - Tool names updated to clearly indicate suite branding:
     - `Embed Query Sequences` -> `Logan Protein Search: Embed Queries`
     - `Search Protein Database` -> `Logan Protein Search: Search Database`
   - Explicit parameter labels and help text emphasizing that **Amino Acid (Protein) FASTA** is strictly required (preventing users from supplying nucleotide/CDS FASTA).
   - Human-readable labels for MMseqs2 alignment formats (`Tabular with column headers`, `Standard BLAST tabular / m8`, etc.) rather than exposing raw CLI numbers `(0)`, `(1)`.
   - Fixed trailing syntax typo `)` in `--deep-search` help text.
   - Clarified output dataset descriptions, explaining the role of `matches.mmseqs2`, `matches.fasta`, and `all_results.fasta` and how sequence headers link back to Logan SRA accessions.
   - Bumped `@VERSION_SUFFIX@` to `1` (`1.2.2+galaxy1`).

Resolves #1984
CC: @bgruening @SaimMomin12
